### PR TITLE
Fix argoexec version calculation

### DIFF
--- a/charms/argo-controller/src/charm.py
+++ b/charms/argo-controller/src/charm.py
@@ -64,7 +64,8 @@ class ArgoControllerCharm(CharmBase):
         self.model.unit.status = MaintenanceStatus("Setting pod spec")
 
         # Sync the argoproj/argoexec image to the same version
-        version = image_details["imagePath"].split(":")[-1]
+        metadata = yaml.safe_load(Path("metadata.yaml").read_bytes())
+        version = metadata["resources"]["oci-image"]["upstream-source"].split(":")[-1]
         executor_image = f"argoproj/argoexec:{version}"
         self.log.info(f"using executorImage {executor_image}")
 


### PR DESCRIPTION
Charmhub has different SHA hashes than when deploying locally. Update version calculation of `argoproj/argoexec` to account for this