### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -3,6 +3,7 @@
 name: argo-controller
 summary: Container-Native Workflow Engine for Kubernetes
 description: Container-Native Workflow Engine for Kubernetes
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:

--- a/charms/argo-server/metadata.yaml
+++ b/charms/argo-server/metadata.yaml
@@ -3,6 +3,7 @@
 name: argo-server
 summary: Container-Native Workflow Engine for Kubernetes
 description: Container-Native Workflow Engine for Kubernetes
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:


### PR DESCRIPTION
This PR addresses https://github.com/canonical/bundle-kubeflow/issues/425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.
