### PR TITLE
Removed prometheus-app direct relation in test

### DIFF
--- a/charms/argo-controller/tests/integration/test_charm.py
+++ b/charms/argo-controller/tests/integration/test_charm.py
@@ -141,7 +141,6 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     await ops_test.model.deploy(grafana, channel="latest/beta")
     await ops_test.model.add_relation(prometheus, grafana)
     await ops_test.model.add_relation(APP_NAME, grafana)
-    await ops_test.model.add_relation(prometheus, APP_NAME)
     await ops_test.model.deploy(
         prometheus_scrape_charm,
         channel="latest/beta",


### PR DESCRIPTION
Update of https://github.com/canonical/argo-operators/pull/28 according to latest Observability Team's review: removed the direct relation between prometheus and argo-controller.