### PR TITLE
 fixes to avoid CI issues caused by observability test cases

### DIFF
--- a/charms/argo-controller/test-integration-requirements.txt
+++ b/charms/argo-controller/test-integration-requirements.txt
@@ -2,3 +2,4 @@
 # See LICENSE file for licensing details.
 
 pytest-operator > 0.8.2
+tenacity<8.1

--- a/charms/argo-controller/test-requirements.txt
+++ b/charms/argo-controller/test-requirements.txt
@@ -1,5 +1,5 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
-juju<3.0
+
 pytest
 pyyaml

--- a/charms/argo-controller/tests/integration/test_charm.py
+++ b/charms/argo-controller/tests/integration/test_charm.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import requests
+import tenacity
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -134,26 +135,28 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     """Deploy prometheus, grafana and required relations, then test the metrics."""
     prometheus = "prometheus-k8s"
     grafana = "grafana-k8s"
-    prometheus_scrape_charm = "prometheus-scrape-config-k8s"
+    prometheus_scrape = "prometheus-scrape-config-k8s"
     scrape_config = {"scrape_interval": "30s"}
 
+    # Deploy and relate prometheus
     await ops_test.model.deploy(prometheus, channel="latest/edge", trust=True)
     await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(
+        prometheus_scrape, channel="latest/beta", config=scrape_config
+    )
+
+    await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
     await ops_test.model.add_relation(
         f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
     )
     await ops_test.model.add_relation(
         f"{APP_NAME}:grafana-dashboard", f"{grafana}:grafana-dashboard"
     )
-    await ops_test.model.deploy(
-        prometheus_scrape_charm,
-        channel="latest/beta",
-        config=scrape_config)
-    await ops_test.model.add_relation(APP_NAME, prometheus_scrape_charm)
     await ops_test.model.add_relation(
-        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape_charm}:metrics-endpoint"
+        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
     )
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
+
+    await ops_test.model.wait_for_idle(status="active", timeout=60 * 20)
 
     status = await ops_test.model.get_status()
     prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
@@ -161,14 +164,29 @@ async def test_prometheus_grafana_integration(ops_test: OpsTest):
     ]
     log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
 
-    r = requests.get(
-        f'http://{prometheus_unit_ip}:9090/api/v1/query?query=up{{juju_application="{APP_NAME}"}}'
-    )
-    response = json.loads(r.content.decode("utf-8"))
-    response_status = response["status"]
-    log.info(f"Response status is {response_status}")
-    assert response_status == "success"
+    for attempt in retry_for_5_attempts:
+        log.info(
+            f"Testing prometheus deployment (attempt "
+            f"{attempt.retry_state.attempt_number})"
+        )
+        with attempt:
+            r = requests.get(
+                f"http://{prometheus_unit_ip}:9090/api/v1/query?"
+                f'query=up{{juju_application="{APP_NAME}"}}'
+            )
+            response = json.loads(r.content.decode("utf-8"))
+            response_status = response["status"]
+            log.info(f"Response status is {response_status}")
+            assert response_status == "success"
 
-    response_metric = response["data"]["result"][0]["metric"]
-    assert response_metric["juju_application"] == APP_NAME
-    assert response_metric["juju_model"] == ops_test.model_name
+            response_metric = response["data"]["result"][0]["metric"]
+            assert response_metric["juju_application"] == APP_NAME
+            assert response_metric["juju_model"] == ops_test.model_name
+
+
+# Helper to retry calling a function over 30 seconds or 5 attempts
+retry_for_5_attempts = tenacity.Retrying(
+    stop=(tenacity.stop_after_attempt(5) | tenacity.stop_after_delay(30)),
+    wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
+    reraise=True,
+)


### PR DESCRIPTION
Pin python-libjuju to 3.0 and update prometheus_grafana test case.
Also, revert a wrongly pushed commit.