### PR TITLE
feat: Enable publish-on-click from any branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,20 +3,27 @@ name: Publish
 
 on:
   workflow_call:
+    inputs:
+      source_branch:
+        description: Github branch from this repo to publish.  If blank, will use the default branch
+        default: ''
+        required: false
+        type: string
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: true
   workflow_dispatch:
     inputs:
-      # TODO: Implement this
-      # source_github_branch:
-      #   description: Source branch to publish
-      #   required: false
-      #   default: 'main'
       destination_channel:
         description: CharmHub channel to publish to
         required: false
         default: 'latest/edge'
+        type: string
+      source_branch:
+        description: Github branch from this repo to publish.  If blank, will use the default branch
+        required: false
+        default: ''
+        type: string
 
 jobs:
   get-charm-paths:
@@ -26,6 +33,9 @@ jobs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
       - uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
+          ref: ${{ inputs.source_branch }}
       - name: Get paths for all charms in repo
         id: get-charm-paths
         run: bash .github/workflows/get-charm-paths.sh
@@ -45,6 +55,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.0.0-rc


### PR DESCRIPTION
Allows the publish.yaml `workflow_dispatch` to be run using any branch in this repo.  See [this test repo](https://github.com/ca-scribner/test-charm/blob/main/.github/workflows/publish.yaml) for the updated action.  You can run_workflow [here](https://github.com/ca-scribner/test-charm/actions/workflows/publish.yaml) with an optional github branch argument.  To demonstrate that it worked, [this branch `another-branch`](https://github.com/ca-scribner/test-charm/tree/another-branch), which has the file `src/file-on-branch-only` was promoted from the branch in [this action run](https://github.com/ca-scribner/test-charm/actions/runs/2863188096) to `latest/candidate`, which can be confirmed through `juju download ca-scribner-test-charm --channel latest/candidate`