### PR TITLE
Add basic alert rules for Argo Workflow (Discard this PR)

### DIFF
--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -2,23 +2,33 @@
 # See LICENSE file for licensing details.
 name: argo-controller
 summary: Container-Native Workflow Engine for Kubernetes
-description: Container-Native Workflow Engine for Kubernetes
+description: |
+  Container-Native Workflow Engine for Kubernetes
+
 min-juju-version: "2.9.0"
-series: [kubernetes]
+series: 
+  - kubernetes
+assumes:
+  - k8s-api
+
 resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
     upstream-source: argoproj/workflow-controller:v3.3.8
+
 requires:
   object-storage:
     interface: object-storage
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
-    versions: [v1]
+    versions: 
+      - v1
+
 deployment:
   type: stateless
   service: omit
+
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/charms/argo-controller/src/prometheus_alert_rules/loglines_error.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/loglines_error.rule
@@ -1,0 +1,17 @@
+alert: ArgoWorkflowErrorLoglines
+expr: |
+  increase(log_messages{level="error"}[2m])
+  > 10
+for: 4m
+labels:
+  severity: critical 
+annotations:
+  summary:  
+  description: |
+    The Argo controller warning logs has increased by at least
+    10 lines per minute for the last 4 minutes.
+
+    Model: {{ $labels.juju_model }}
+    Application: {{ $labels.juju_application }}
+
+    LABELS = {{ $labels }}

--- a/charms/argo-controller/src/prometheus_alert_rules/loglines_warning.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/loglines_warning.rule
@@ -1,0 +1,17 @@
+alert: ArgoWorkflowWarningLoglines
+expr: |
+  increase(log_messages{level="warning"}[2m])
+  > 40
+for: 4m
+labels:
+  severity: warning
+annotations:
+  summary:  
+  description: |
+    The Argo controller warning logs has increased by at least 
+    40 lines per minute for the last 4 minutes.
+
+    Model: {{ $labels.juju_model }}
+    Application: {{ $labels.juju_application }}
+
+    LABELS = {{ $labels }}

--- a/charms/argo-controller/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/unit_unavailable.rule
@@ -4,7 +4,8 @@ for: 0m
 labels:
   severity: critical
 annotations:
-  summary: Argo unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} unavailable
+  summary: >
+    Argo unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} unavailable
   description: >
     The argo unit {{ $labels.juju_model }} {{ $labels.juju_unit }} is unavailable
     LABELS = {{ $labels }}

--- a/charms/argo-controller/src/prometheus_alert_rules/workflows_erroring.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/workflows_erroring.rule
@@ -1,0 +1,13 @@
+alert: ArgoWorkflowsErroring
+expr: |
+  increase(
+    argo_workflows_count{status="Error"}[2m]
+  ) > 1
+for: 10m
+labels:
+  severity: warning
+annotations:
+  summary: Amount of erroring Argo Workflows is increasing!
+  description: >
+    The argo workflows spawned by {{ $labels.juju_model }} {{ $labels.juju_application }} are erroring.
+    LABELS = {{ $labels }}

--- a/charms/argo-controller/src/prometheus_alert_rules/workflows_failing.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/workflows_failing.rule
@@ -1,0 +1,14 @@
+alert: ArgoWorkflowsFailed
+expr: |
+  increase(
+    argo_workflows_count{status="Failed"}[2m]
+  ) > 1
+for: 10m
+labels:
+  severity: warning
+annotations:
+  summary: >
+    Amount of failing Argo Workflows is increasing.
+  description: >
+    The argo workflows spawned by {{ $labels.juju_model }} {{ $labels.juju_application }} are failing.
+    LABELS = {{ $labels }}

--- a/charms/argo-controller/src/prometheus_alert_rules/workflows_pending.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/workflows_pending.rule
@@ -1,0 +1,17 @@
+alert: ArgoWorkflowsPending
+expr: |
+  increase(
+    argo_workflows_count{status="Pending"}[2m]
+  ) > 1
+for: 10m
+labels:
+  severity: warning
+annotations:
+  summary: >
+    Amount of pending Argo Workflows is increasing.
+  description: >
+    The amount of pending argo workflows spawned by
+    {{ $labels.juju_application }} in model {{ $labels.juju_model }}
+    is increasing.
+
+    LABELS = {{ $labels }}


### PR DESCRIPTION
This PR adds basic alert rules for the Argo Workflow charm. It also resolves the bug where the charm is allowing for deployments to LXD although it will never be able to do anything.

