### PR TITLE
fix: pip-compile `fileMatch` in `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,11 @@
     },
     "pip-compile": {
         "fileMatch": [
-            "(^|/)requirements.in",
-            "(^|/)requirements-fmt.in",
-            "(^|/)requirements-lint.in",
-            "(^|/)requirements-unit.in",
-            "(^|/)requirements-integration.in",
+            "(^|/)requirements\\.in$",
+            "(^|/)requirements-fmt\\.in$",
+            "(^|/)requirements-lint\\.in$",
+            "(^|/)requirements-unit\\.in$",
+            "(^|/)requirements-integration\\.in$",
             "(^|/)requirements.*\\.in$"
         ],
         "lockFileMaintenance": {


### PR DESCRIPTION
Previously, the pattern `(^|/)requirements.in` was accidentally matching the file `requirements-integration.txt` as a pip-compile file because:
* the `.` in the pattern is a wildcard not a literal period
* the pattern has no end-of-string match

So as it was, the pattern would match the starting `requirements-in` in `requirements-integration.txt`.  This change corrects that by escaping the period and adding end of string matches to all the patterns.