### PR TITLE
docs: add documentation links to metadata.yaml

### DIFF
--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -3,6 +3,10 @@
 name: argo-controller
 summary: Container-Native Workflow Engine for Kubernetes
 description: Container-Native Workflow Engine for Kubernetes
+website: https://charmhub.io/argo-controller
+source: https://github.com/canonical/argo-operators/argo-controller
+issues: https://github.com/canonical/argo-operators/issues
+docs: https://discourse.charmhub.io/t/argo-controller/8212
 min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:

--- a/charms/argo-server/metadata.yaml
+++ b/charms/argo-server/metadata.yaml
@@ -3,6 +3,10 @@
 name: argo-server
 summary: Container-Native Workflow Engine for Kubernetes
 description: Container-Native Workflow Engine for Kubernetes
+website: https://charmhub.io/argo-server
+source: https://github.com/canonical/argo-operators/argo-server
+issues: https://github.com/canonical/argo-operators/issues
+docs: https://discourse.charmhub.io/t/charmed-argo-server/8212
 min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:


### PR DESCRIPTION
These links in the charm's metadata will be rendered in charmhub.io to get access to relevant information/docs.