### PR TITLE
tests: pin python-libjuju<3.1 to avoid unsupported version errors

### DIFF
--- a/charms/argo-controller/requirements-integration.in
+++ b/charms/argo-controller/requirements-integration.in
@@ -1,6 +1,6 @@
 aiohttp
 jinja2
-juju
+juju<3.1
 pytest-operator
 requests
 tenacity


### PR DESCRIPTION
Apparently the juju agent 2.9.34 is not compatible with pythonlib-juju 3.1, causing the following error:
`juju.errors.JujuConnectionError: juju server-version 2.9.34 not supported `
To avoid this, we have to pin to a version below 3.1.