### PR TITLE
Changed interval for argo controller prometheus

### DIFF
--- a/charms/argo-controller/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,6 +1,6 @@
 alert: ArgoUnitIsUnavailable
 expr: up < 1
-for: 0m
+for: 5m
 labels:
   severity: critical
 annotations:


### PR DESCRIPTION
As stated in issue https://github.com/canonical/bundle-kubeflow/issues/564 the duation for alerts for argo is set to 0m, which is too low for prod environments. We need to change to at least 5m to prevent the flapping behavior.

Partial-Bug: https://github.com/canonical/bundle-kubeflow/issues/564