### PR TITLE
feat: version bump 3.3.8 -> 3.3.9

### DIFF
--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: argoproj/workflow-controller:v3.3.8
+    upstream-source: argoproj/workflow-controller:v3.3.9
 requires:
   object-storage:
     interface: object-storage

--- a/charms/argo-server/metadata.yaml
+++ b/charms/argo-server/metadata.yaml
@@ -14,7 +14,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: argoproj/argocli:v3.3.8
+    upstream-source: argoproj/argocli:v3.3.9
 deployment:
   type: stateless
   service: omit


### PR DESCRIPTION
Bump the argo patch version as a candidate fix for [this](https://discourse.charmhub.io/t/upgrade-argo-to-3-3-9-to-support-enhanced-depends/10795) issue.

According to the [Release Notes](https://github.com/argoproj/argo-workflows/releases/tag/v3.3.9):
* [Fixes](https://github.com/argoproj/argo-workflows/blob/master/CHANGELOG.md#v339-2022-08-09) were introduced in 3.3.9
* No apparent breaking changes are introduced