### PR TITLE
Cherry pick (DO NOT MERGE)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.2
+        uses: canonical/charming-actions/channel@2.3.0
         id: select-channel
         if: ${{ inputs.destination_channel == '' }}
 
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.2
+        uses: canonical/charming-actions/upload-charm@2.3.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.2.2
+        uses: canonical/charming-actions/release-charm@2.3.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/charms/argo-controller/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,6 +1,6 @@
 alert: ArgoUnitIsUnavailable
 expr: up < 1
-for: 0m
+for: 5m
 labels:
   severity: critical
 annotations:

--- a/renovate.json
+++ b/renovate.json
@@ -1,48 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "rebaseWhen": "behind-base-branch",
-    "dependencyDashboard": false,
-    "branchPrefix": "renovate-",
-    "constraints": {
-        "python": "3.8.0"
-    },
-    "pip-compile": {
-        "fileMatch": [
-            "(^|/)requirements\\.in$",
-            "(^|/)requirements-fmt\\.in$",
-            "(^|/)requirements-lint\\.in$",
-            "(^|/)requirements-unit\\.in$",
-            "(^|/)requirements-integration\\.in$",
-            "(^|/)requirements.*\\.in$"
-        ],
-        "lockFileMaintenance": {
-            "enabled": true,
-            "schedule": null
-        }
-    },
-    "pip_requirements": {
-        "enabled": false
-    },
-    "automergeType": "branch",
-    "packageRules": [
-        {
-            "groupName": "testing deps",
-            "matchPackagePatterns": [
-                "^black$",
-                "codespell",
-                "flake8",
-                "flake8-builtins",
-                "flake8-copyright",
-                "flake8-docstrings",
-                "isort",
-                "pep8-naming",
-                "pyproject-flake8",
-                "pytest",
-                "pytest-asyncio",
-                "selenium",
-                "selenium-wire"
-            ],
-            "automerge": true
-        }
+    "extends": [
+        "github>canonical/charmed-kubeflow-workflows"
     ]
 }

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+)
+# dynamic list
+git checkout origin/track/3.3
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+VERSION=$(grep upstream-source charms/argo-controller/metadata.yaml | awk -F':' '{print $3}')
+IMAGE_LIST+=($(grep "executor_image =" charms/argo-controller/src/charm.py | awk '{print $3}' | sed s/f//g | sed s/\"//g | sed s/{version}/$VERSION/g))
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
    feat: get images
    
    Repository specific list of images.
    Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.
    
    Summary of changes:
    - Added script that retrieves image managed by charm(s).