### PR TITLE
feat: get images (DO NOT MERGE - check kubeflow-ci PR first)

### DIFF
--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+)
+# dynamic list
+git checkout origin/track/3.3
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+VERSION=$(grep upstream-source charms/argo-controller/metadata.yaml | awk -F':' '{print $3}')
+IMAGE_LIST+=($(grep "executor_image =" charms/argo-controller/src/charm.py | awk '{print $3}' | sed s/f//g | sed s/\"//g | sed s/{version}/$VERSION/g))
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Added script that retrieves image managed by charm(s).