### PR TITLE
feat add branches to bundle (DO NOT MERGE)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -4,30 +4,21 @@ name: CI
 on:
   workflow_call:
     secrets:
-      charmcraft-credentials:
+      CHARMCRAFT_CREDENTIALS:
         required: true
 
 jobs:
-
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         charm:
         - argo-controller
         - argo-server
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Check libs
-      uses: canonical/charming-actions/check-libraries@2.2.2
-      with:
-        charm-path: ./charms/${{ matrix.charm }}
-        credentials: "${{ secrets.charmcraft-credentials }}"
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
+    secrets: inherit
+    with:
+      charm-path: ./charms/${{ matrix.charm }}
 
   lint:
     name: Lint Code

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,12 +12,10 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
-    secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -3,14 +3,13 @@ name: On Push
 # On push to a "special" branch, we:
 # * always publish to charmhub at latest/edge/branchname
 # * always run tests
-# where a "special" branch is one of main/master or track/**, as
+# where a "special" branch is one of main or track/**, as
 # by convention these branches are the source for a corresponding
 # charmhub edge channel.
 
 on:
   push:
     branches:
-    - master
     - main
     - track/**
 
@@ -19,13 +18,11 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
-    secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:
     name: Publish Charm
     needs: tests
     uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+VERSION=$(grep upstream-source charms/argo-controller/metadata.yaml | awk -F':' '{print $3}')
+IMAGE_LIST+=($(grep "executor_image =" charms/argo-controller/src/charm.py | awk '{print $3}' | sed s/f//g | sed s/\"//g | sed s/{version}/$VERSION/g))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
Repository specific list of images
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.
Script is specific for track/1.7 branch to capture all images for that branch.
Branch is handled in kubeflow-ci and bundle automation using bundle file.
    
Summary of changes:
- Re-designed get images script to retrieve all images for current branch. Branch management is done outside of this script.
