### PR TITLE
feat: updated get images script without branch checkout for track/3.3

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+VERSION=$(grep upstream-source charms/argo-controller/metadata.yaml | awk -F':' '{print $3}')
+IMAGE_LIST+=($(grep "executor_image =" charms/argo-controller/src/charm.py | awk '{print $3}' | sed s/f//g | sed s/\"//g | sed s/{version}/$VERSION/g))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
Repository specific list of images
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup. Script is specific for track/3.3 branch to capture all images for that branch. Branch is handled in kubeflow-ci and bundle automation using bundle file.

Summary of changes:
- Re-designed get images script to retrieve all images for current branch. Branch management is done outside of this script.