### PR TITLE
build: bump juju 2.9.44.0, sdi->0.7.0, pyyaml->6.0.1

### DIFF
--- a/charms/argo-controller/requirements-integration.in
+++ b/charms/argo-controller/requirements-integration.in
@@ -1,6 +1,7 @@
 aiohttp
 jinja2
-juju<3.1
+# Pinning to <3.0 due to compatibility with the 2.9 controller version and 3.0 not being maintained anymore
+juju<3.0
 pytest-operator
 requests
 tenacity

--- a/charms/argo-controller/requirements-integration.txt
+++ b/charms/argo-controller/requirements-integration.txt
@@ -60,6 +60,10 @@ idna==2.10
     #   -r requirements.txt
     #   requests
     #   yarl
+importlib-resources==6.0.0
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 iniconfig==1.1.1
     # via pytest
 ipdb==0.13.9
@@ -72,11 +76,11 @@ jinja2==3.1.2
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-jsonschema==3.2
+jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-juju==3.0.4
+juju==2.9.44.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -116,6 +120,10 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pluggy==1.0.0
     # via pytest
 prompt-toolkit==3.0.36
@@ -164,7 +172,7 @@ python-dateutil==2.8.2
     # via kubernetes
 pytz==2022.6
     # via pyrfc3339
-pyyaml==5.4
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   juju
@@ -186,13 +194,12 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
-serialized-data-interface==0.4.0
+serialized-data-interface==0.7.0
     # via -r requirements.txt
 six==1.16.0
     # via
-    #   -r requirements.txt
+    #   asttokens
     #   google-auth
-    #   jsonschema
     #   kubernetes
     #   macaroonbakery
     #   paramiko
@@ -231,6 +238,10 @@ websockets==7.0
     # via juju
 yarl==1.8.2
     # via aiohttp
+zipp==3.16.2
+    # via
+    #   -r requirements.txt
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/charms/argo-controller/requirements-unit.txt
+++ b/charms/argo-controller/requirements-unit.txt
@@ -25,9 +25,13 @@ idna==2.10
     # via
     #   -r requirements.txt
     #   requests
+importlib-resources==6.0.0
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 iniconfig==1.1.1
     # via pytest
-jsonschema==3.2
+jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
@@ -39,6 +43,10 @@ ops==1.5.4
     #   serialized-data-interface
 packaging==22.0
     # via pytest
+pkgutil-resolve-name==1.3.10
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pluggy==1.0.0
     # via pytest
 pyrsistent==0.19.2
@@ -54,27 +62,24 @@ pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
 pytest-mock==3.10.0
     # via -r requirements-unit.in
-pyyaml==5.4
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   ops
     #   serialized-data-interface
-requests==2.25
+requests==2.25.0
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-serialized-data-interface==0.4.0
+serialized-data-interface==0.7.0
     # via -r requirements.txt
-six==1.16.0
-    # via
-    #   -r requirements.txt
-    #   jsonschema
 tomli==2.0.1
     # via pytest
 urllib3==1.26.13
     # via
     #   -r requirements.txt
     #   requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.16.2
+    # via
+    #   -r requirements.txt
+    #   importlib-resources

--- a/charms/argo-controller/requirements.txt
+++ b/charms/argo-controller/requirements.txt
@@ -12,7 +12,9 @@ chardet==3.0.4
     # via requests
 idna==2.10
     # via requests
-jsonschema==3.2
+importlib-resources==6.0.0
+    # via jsonschema
+jsonschema==4.17.3
     # via serialized-data-interface
 oci-image==1.0.0
     # via -r requirements.in
@@ -20,20 +22,19 @@ ops==1.5.4
     # via
     #   -r requirements.in
     #   serialized-data-interface
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 pyrsistent==0.19.2
     # via jsonschema
-pyyaml==5.4
+pyyaml==6.0.1
     # via
     #   ops
     #   serialized-data-interface
-requests==2.25
+requests==2.25.0
     # via serialized-data-interface
-serialized-data-interface==0.4.0
+serialized-data-interface==0.7.0
     # via -r requirements.in
-six==1.16.0
-    # via jsonschema
 urllib3==1.26.13
     # via requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.16.2
+    # via importlib-resources

--- a/charms/argo-server/charmcraft.yaml
+++ b/charms/argo-server/charmcraft.yaml
@@ -12,4 +12,4 @@ bases:
 parts:
   charm:
     # do not use these versions due to pypa/setuptools_scm#713
-    charm-python-packages: [setuptools!=62.2.0, pip!=22.1]
+    charm-python-packages: [setuptools, pip]

--- a/charms/argo-server/requirements-unit.txt
+++ b/charms/argo-server/requirements-unit.txt
@@ -29,7 +29,7 @@ pytest-lazy-fixture==0.6.3
     # via -r requirements-unit.in
 pytest-mock==3.10.0
     # via -r requirements-unit.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.txt

--- a/charms/argo-server/requirements.txt
+++ b/charms/argo-server/requirements.txt
@@ -8,7 +8,7 @@ oci-image==1.0.0
     # via -r requirements.in
 ops==2.1.1
     # via -r requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via ops
 websocket-client==1.5.1
     # via ops


### PR DESCRIPTION
Bump these package versions to avoid the issues described in https://github.com/canonical/bundle-kubeflow/issues/648.

This PR also unpins setuptools and pip in charmcraft.yaml to avoid an issue with versions incompatibilities:

```
 :: Running external command ['/root/parts/charm/build/staging-venv/bin/pip3', 'install', '--upgrade', '--no-binary', ':all:', 'pip', 'setuptools', 'wheel', 'setuptools!=62.2.0', 'pip!=22.1']
::    :: ERROR: Double requirement given: setuptools!=62.2.0 (already in setuptools, name='setuptools')
```