### PR TITLE
fix: change default executor from pns (deprecated) to emissary

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -12,10 +12,11 @@ options:
     description: S3 key prefix
   executor:
     type: string
-    default: pns
+    default: emissary
     description: |
-      Runtime executor for workflow containers. Cannot be `docker` on containerd,
-      for a full list of executors, see https://github.com/argoproj/argo/tree/master/workflow/executor
+      Runtime executor for workflow containers. Defaults to `emissary` as it is the default in both Argo Workflows and
+      the upstream Kubeflow project. Cannot be `docker` on containerd, for a full list of executors, see:
+      https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   kubelet-insecure:
     type: boolean
     default: false


### PR DESCRIPTION
The default executor in argo-controller's charm configuration is now deprecated and removed in more recent versions of argo workflows. We should consider changing the default to emissary, which is actually the default in >=3.3

Fixes #117