### PR TITLE
argo-controller: Add executor-image to config

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -17,6 +17,11 @@ options:
       Runtime executor for workflow containers. Defaults to `emissary` as it is the default in both Argo Workflows and
       the upstream Kubeflow project. Cannot be `docker` on containerd, for a full list of executors, see:
       https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
+  executor-image:
+    type: string
+    default: argoproj/argoexec:v3.3.8
+    description: |
+      Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:
     type: boolean
     default: false

--- a/charms/argo-controller/src/charm.py
+++ b/charms/argo-controller/src/charm.py
@@ -80,10 +80,7 @@ class ArgoControllerCharm(CharmBase):
         self.model.unit.status = MaintenanceStatus("Setting pod spec")
 
         # Sync the argoproj/argoexec image to the same version
-        metadata = yaml.safe_load(Path("metadata.yaml").read_bytes())
-        version = metadata["resources"]["oci-image"]["upstream-source"].split(":")[-1]
-        executor_image = f"argoproj/argoexec:{version}"
-        self.log.info(f"using executorImage {executor_image}")
+        executor_image = self.model.config["executor-image"]
 
         config_map = {
             "containerRuntimeExecutor": self.model.config["executor"],


### PR DESCRIPTION
Add executor-image field in the charm's config file in order to avoid deducing it based on the tag of the container image.

Closes #115