### PR TITLE
fix: ported exec image config

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -16,6 +16,11 @@ options:
     description: |
       Runtime executor for workflow containers. Cannot be `docker` on containerd,
       for a full list of executors, see https://github.com/argoproj/argo/tree/master/workflow/executor
+  executor-image:
+    type: string
+    default: argoproj/argoexec:v3.3.9
+    description: |
+      Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:
     type: boolean
     default: false

--- a/charms/argo-controller/src/charm.py
+++ b/charms/argo-controller/src/charm.py
@@ -79,11 +79,7 @@ class ArgoControllerCharm(CharmBase):
 
         self.model.unit.status = MaintenanceStatus("Setting pod spec")
 
-        # Sync the argoproj/argoexec image to the same version
-        metadata = yaml.safe_load(Path("metadata.yaml").read_bytes())
-        version = metadata["resources"]["oci-image"]["upstream-source"].split(":")[-1]
-        executor_image = f"argoproj/argoexec:{version}"
-        self.log.info(f"using executorImage {executor_image}")
+        executor_image = self.model.config["executor-image"]
 
         config_map = {
             "containerRuntimeExecutor": self.model.config["executor"],


### PR DESCRIPTION
# Description

Porting of executor image configuration is required to enable it configuration in `track/3.3`

# Summary of changes:
- Ported configuration of executor image configuration.
- Issue: https://github.com/canonical/argo-operators/issues/115
- PR on main: https://github.com/canonical/argo-operators/pull/125