### PR TITLE
backport: Update get-images script according main branch (#106 and #124)

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -5,6 +5,5 @@
 IMAGE_LIST=()
 IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
 VERSION=$(grep upstream-source charms/argo-controller/metadata.yaml | awk -F':' '{print $3}')
-IMAGE_LIST+=($(grep "executor_image =" charms/argo-controller/src/charm.py | awk '{print $3}' | sed s/f//g | sed s/\"//g | sed s/{version}/$VERSION/g))
+IMAGE_LIST+=($(yq '.options.executor-image.default' ./charms/argo-controller/config.yaml))
 printf "%s\n" "${IMAGE_LIST[@]}"
-


### PR DESCRIPTION
Get script up-to-date with `main` branch. This summarizes changes introduced in PRs #106 and #124 since the final `get-images.sh` script in `main` branch is different from the one currently in `track/3.3` only by this one line.

Closes #136