### PR TITLE
backport(fix): change default executor from pns (deprecated) to emissary (#122)

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -12,10 +12,11 @@ options:
     description: S3 key prefix
   executor:
     type: string
-    default: pns
+    default: emissary
     description: |
-      Runtime executor for workflow containers. Cannot be `docker` on containerd,
-      for a full list of executors, see https://github.com/argoproj/argo/tree/master/workflow/executor
+      Runtime executor for workflow containers. Defaults to `emissary` as it is the default in both Argo Workflows and
+      the upstream Kubeflow project. Cannot be `docker` on containerd, for a full list of executors, see:
+      https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
     default: argoproj/argoexec:v3.3.9


### PR DESCRIPTION
This PR backports #122 from `main` to `track/3.3`. 
Refs #117