### PR TITLE
fix: rename the secret to access the artifact repository

### DIFF
--- a/charms/argo-controller/src/charm.py
+++ b/charms/argo-controller/src/charm.py
@@ -155,7 +155,7 @@ class ArgoControllerOperator(CharmBase):
             "secret_key": b64encode(
                 self.object_storage_relation.component.get_data()["secret-key"].encode("utf-8")
             ).decode("utf-8"),
-            "mlpipeline_minio_artifact_secret": "mlpipeline-minio-artifact-secret",
+            "mlpipeline_minio_artifact_secret": "mlpipeline-minio-artifact",
             "argo_controller_configmap": ARGO_CONTROLLER_CONFIGMAP,
             "s3_bucket": self.model.config["bucket"],
             "s3_minio_endpoint": (


### PR DESCRIPTION
4b57f05 renamed the Secret argo-controller applies to configure the artifactRepository. This change should be reverted back to mlpipeline-minio-artifact as pipelines depend on this Secret to be named exactly like that.