### PR TITLE
fix: update argo exec rock version

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -19,7 +19,7 @@ options:
       https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
-    default: charmedkubeflow/argoexec:v3.3.9_22.04_1
+    default: charmedkubeflow/argoexec:v3.3.9_22.04_2
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:


### PR DESCRIPTION
updates argo-exec rock version in argo-controller's config.yaml
closes https://github.com/canonical/charmed-kubeflow-uats/issues/38 in `track/3.3`
this change should be done in main as well, PR incoming.