### PR TITLE
fix: remove --namespaced from argo-controller entrypoint

### DIFF
--- a/charms/argo-controller/src/components/pebble_component.py
+++ b/charms/argo-controller/src/components/pebble_component.py
@@ -48,8 +48,7 @@ class ArgoControllerPebbleService(PebbleServiceComponent):
                             "--configmap "
                             f"{ARGO_CONTROLLER_CONFIGMAP} "
                             "--executor-image "
-                            f"{self.model.config[EXECUTOR_IMAGE_CONFIG_NAME]} "
-                            "--namespaced"
+                            f"{self.model.config[EXECUTOR_IMAGE_CONFIG_NAME]}"
                         ),
                         "startup": "enabled",
                         "environment": self.environment,


### PR DESCRIPTION
closes #143, details in the issue.

## Testing
Run the `kfp-integration` UATs with `tox -e uats -- --filter "kfp-integration"`
instructions on running the UATs in their [readme](https://github.com/canonical/charmed-kubeflow-uats#run-the-tests)