### PR TITLE
chore: use argoproj/argoexec:v3.3.10 as default argoexec image

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -19,7 +19,7 @@ options:
       https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
-    default: charmedkubeflow/argoexec:v3.3.10_22.04_1
+    default: argoproj/argoexec:v3.3.10
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:


### PR DESCRIPTION
This commit defaults the executor image to argoproj/argoexec:v3.3.10 to bump the version and avoid canonical/charmed-kubeflow-uats#38.