### PR TITLE
feat: use argoexec rock v3.3.10

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -19,7 +19,7 @@ options:
       https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
-    default: argoproj/argoexec:v3.3.10
+    default: charmedkubeflow/argoexec:3.3.10-c88862f
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:


### PR DESCRIPTION
integrates the `argoexec` rock `v3.3.10` in the `argo-controller` charm published from https://github.com/canonical/argo-workflows-rocks/commit/c88862fa80c469ef44cfb2cd89e501b6dd3f5ebf