### PR TITLE
feat: use argoexec rock v3.3.10 (#158)

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -19,7 +19,7 @@ options:
       https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
-    default: argoproj/argoexec:v3.3.10
+    default: charmedkubeflow/argoexec:3.3.10-c88862f
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:


### PR DESCRIPTION
integrates `argoexec` rock in `track/3.3.10`
cherry-picks 3654e8b96c254006cf543e145c76bd15d9d84b72