### PR TITLE
chore: bump argo-controller 3.3.10 -> 3.4

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -10,13 +10,6 @@ options:
     type: string
     default: "artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}"
     description: S3 key prefix
-  executor:
-    type: string
-    default: emissary
-    description: |
-      Runtime executor for workflow containers. Defaults to `emissary` as it is the default in both Argo Workflows and
-      the upstream Kubeflow project. Cannot be `docker` on containerd, for a full list of executors, see:
-      https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
     default: gcr.io/ml-pipeline/argoexec:v3.4.16-license-compliance

--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -19,7 +19,7 @@ options:
       https://argoproj.github.io/argo-workflows/workflow-executors/#workflow-executors
   executor-image:
     type: string
-    default: charmedkubeflow/argoexec:3.3.10-c88862f
+    default: gcr.io/ml-pipeline/argoexec:v3.4.16-license-compliance
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:

--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: gcr.io/ml-pipeline/argoexec:v3.4.16-license-compliance
+    upstream-source: gcr.io/ml-pipeline/workflow-controller:v3.4.16-license-compliance
 containers:
   argo-controller:
     resource: oci-image

--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: argoproj/workflow-controller:v3.3.10
+    upstream-source: gcr.io/ml-pipeline/argoexec:v3.4.16-license-compliance
 containers:
   argo-controller:
     resource: oci-image

--- a/charms/argo-controller/src/charm.py
+++ b/charms/argo-controller/src/charm.py
@@ -164,7 +164,6 @@ class ArgoControllerOperator(CharmBase):
                 f"{self.object_storage_relation.component.get_data()['port']}"
             ),
             "kubelet_insecure": self.model.config["kubelet-insecure"],
-            "runtime_executor": self.model.config["executor"],
         }
 
 

--- a/charms/argo-controller/src/templates/crds.yaml
+++ b/charms/argo-controller/src/templates/crds.yaml
@@ -1,8 +1,11 @@
-# From argo-workflows/manifests/quick-start-minimal.yaml
-# Only CRDs
+# From manifests/apps/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user (v1.9-branch)
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|clusterworkflowtemplates.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: clusterworkflowtemplates.argoproj.io
 spec:
   group: argoproj.io
@@ -40,6 +43,330 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved, request not yet submitted
+  labels:
+    application-crd-id: kubeflow-pipelines
+    kustomize.component: metacontroller
+  name: compositecontrollers.metacontroller.k8s.io
+spec:
+  group: metacontroller.k8s.io
+  names:
+    kind: CompositeController
+    listKind: CompositeControllerList
+    plural: compositecontrollers
+    shortNames:
+    - cc
+    - cctl
+    singular: compositecontroller
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              childResources:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    resource:
+                      type: string
+                    updateStrategy:
+                      properties:
+                        method:
+                          type: string
+                        statusChecks:
+                          properties:
+                            conditions:
+                              items:
+                                properties:
+                                  reason:
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  required:
+                  - apiVersion
+                  - resource
+                  type: object
+                type: array
+              generateSelector:
+                type: boolean
+              hooks:
+                properties:
+                  customize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  finalize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  postUpdateChild:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  preUpdateChild:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  sync:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              parentResource:
+                properties:
+                  apiVersion:
+                    type: string
+                  resource:
+                    type: string
+                  revisionHistory:
+                    properties:
+                      fieldPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                required:
+                - apiVersion
+                - resource
+                type: object
+              resyncPeriodSeconds:
+                format: int32
+                type: integer
+            required:
+            - parentResource
+            type: object
+          status:
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved, request not yet submitted
+  labels:
+    application-crd-id: kubeflow-pipelines
+    kustomize.component: metacontroller
+  name: controllerrevisions.metacontroller.k8s.io
+spec:
+  group: metacontroller.k8s.io
+  names:
+    kind: ControllerRevision
+    listKind: ControllerRevisionList
+    plural: controllerrevisions
+    singular: controllerrevision
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          children:
+            items:
+              properties:
+                apiGroup:
+                  type: string
+                kind:
+                  type: string
+                names:
+                  items:
+                    type: string
+                  type: array
+              required:
+              - apiGroup
+              - kind
+              - names
+              type: object
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          parentPatch:
+            type: object
+        required:
+        - metadata
+        - parentPatch
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|cronworkflows.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: cronworkflows.argoproj.io
 spec:
   group: argoproj.io
@@ -81,6 +408,397 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved, request not yet submitted
+  labels:
+    application-crd-id: kubeflow-pipelines
+    kustomize.component: metacontroller
+  name: decoratorcontrollers.metacontroller.k8s.io
+spec:
+  group: metacontroller.k8s.io
+  names:
+    kind: DecoratorController
+    listKind: DecoratorControllerList
+    plural: decoratorcontrollers
+    shortNames:
+    - dec
+    - decorators
+    singular: decoratorcontroller
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              attachments:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    resource:
+                      type: string
+                    updateStrategy:
+                      properties:
+                        method:
+                          type: string
+                      type: object
+                  required:
+                  - apiVersion
+                  - resource
+                  type: object
+                type: array
+              hooks:
+                properties:
+                  customize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  finalize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  sync:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              resources:
+                items:
+                  properties:
+                    annotationSelector:
+                      properties:
+                        matchAnnotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        matchExpressions:
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                      type: object
+                    apiVersion:
+                      type: string
+                    labelSelector:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    resource:
+                      type: string
+                  required:
+                  - apiVersion
+                  - resource
+                  type: object
+                type: array
+              resyncPeriodSeconds:
+                format: int32
+                type: integer
+            required:
+            - resources
+            type: object
+          status:
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+    application-crd-id: kubeflow-pipelines
+  name: scheduledworkflows.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: ScheduledWorkflow
+    listKind: ScheduledWorkflowList
+    plural: scheduledworkflows
+    shortNames:
+    - swf
+    singular: scheduledworkflow
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        - status
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+    application-crd-id: kubeflow-pipelines
+  name: viewers.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: Viewer
+    listKind: ViewerList
+    plural: viewers
+    shortNames:
+    - vi
+    singular: viewer
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflowartifactgctasks.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
+  name: workflowartifactgctasks.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: WorkflowArtifactGCTask
+    listKind: WorkflowArtifactGCTaskList
+    plural: workflowartifactgctasks
+    shortNames:
+    - wfat
+    singular: workflowartifactgctask
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-map-type: atomic
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workfloweventbindings.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: workfloweventbindings.argoproj.io
 spec:
   group: argoproj.io
@@ -117,6 +835,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflows.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: workflows.argoproj.io
 spec:
   group: argoproj.io
@@ -139,6 +861,11 @@ spec:
       jsonPath: .status.startedAt
       name: Age
       type: date
+    - description: Human readable message indicating details about why the workflow
+        is in this condition.
+      jsonPath: .status.message
+      name: Message
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -168,6 +895,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflowtaskresults.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: workflowtaskresults.argoproj.io
 spec:
   group: argoproj.io
@@ -210,6 +941,29 @@ spec:
                       type: object
                     archiveLogs:
                       type: boolean
+                    artifactGC:
+                      properties:
+                        podMetadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        serviceAccountName:
+                          type: string
+                        strategy:
+                          enum:
+                          - ""
+                          - OnWorkflowCompletion
+                          - OnWorkflowDeletion
+                          - Never
+                          type: string
+                      type: object
                     artifactory:
                       properties:
                         passwordSecret:
@@ -239,6 +993,34 @@ spec:
                       required:
                       - url
                       type: object
+                    azure:
+                      properties:
+                        accountKeySecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        blob:
+                          type: string
+                        container:
+                          type: string
+                        endpoint:
+                          type: string
+                        useSDKCreds:
+                          type: boolean
+                      required:
+                      - blob
+                      - container
+                      - endpoint
+                      type: object
+                    deleted:
+                      type: boolean
                     from:
                       type: string
                     fromExpression:
@@ -265,6 +1047,8 @@ spec:
                       type: object
                     git:
                       properties:
+                        branch:
+                          type: string
                         depth:
                           format: int64
                           type: integer
@@ -291,6 +1075,8 @@ spec:
                           type: string
                         revision:
                           type: string
+                        singleBranch:
+                          type: boolean
                         sshPrivateKeySecret:
                           properties:
                             key:
@@ -374,6 +1160,110 @@ spec:
                       type: object
                     http:
                       properties:
+                        auth:
+                          properties:
+                            basicAuth:
+                              properties:
+                                passwordSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                usernameSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            clientCert:
+                              properties:
+                                clientCertSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                clientKeySecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                            oauth2:
+                              properties:
+                                clientIDSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                clientSecretSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                endpointParams:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - key
+                                    type: object
+                                  type: array
+                                scopes:
+                                  items:
+                                    type: string
+                                  type: array
+                                tokenURLSecret:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          type: object
                         headers:
                           items:
                             properties:
@@ -594,6 +1484,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflowtasksets.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: workflowtasksets.argoproj.io
 spec:
   group: argoproj.io
@@ -636,6 +1530,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: apiextensions.k8s.io|CustomResourceDefinition|default|workflowtemplates.argoproj.io
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: workflowtemplates.argoproj.io
 spec:
   group: argoproj.io

--- a/charms/argo-controller/src/templates/minio_configmap.yaml.j2
+++ b/charms/argo-controller/src/templates/minio_configmap.yaml.j2
@@ -2,8 +2,8 @@ apiVersion: v1
 data:
   artifactRepository: |
     s3:
-      bucket: {{ s3_bucket }}
       endpoint: {{ s3_minio_endpoint }}
+      bucket: {{ s3_bucket }}
       insecure: {{ kubelet_insecure }}
       accessKeySecret:
         name: {{ mlpipeline_minio_artifact_secret }}
@@ -11,34 +11,9 @@ data:
       secretKeySecret:
         name: {{ mlpipeline_minio_artifact_secret }}
         key: secretkey
-  containerRuntimeExecutors: |
-    - name: {{ runtime_executor }}
-      selector:
-        matchLabels:
-          workflows.argoproj.io/container-runtime-executor: {{ runtime_executor }}
+  containerRuntimeExecutor: {{ runtime_executor }}
   executor: |
-    resources:
-      requests:
-        cpu: 10m
-        memory: 64Mi
-  images: |
-    argoproj/argosay:v1:
-      command: [cowsay]
-    argoproj/argosay:v2:
-      command: [/argosay]
-    docker/whalesay:latest:
-       command: [cowsay]
-    python:alpine3.6:
-       command: [python3]
-  metricsConfig: |
-    enabled: true
-    path: /metrics
-    port: 9090
-  namespaceParallelism: "10"
-  retentionPolicy: |
-    completed: 10
-    failed: 3
-    errored: 3
+    imagePullPolicy: IfNotPresent
 kind: ConfigMap
 metadata:
   name: {{ argo_controller_configmap }}

--- a/charms/argo-controller/src/templates/minio_configmap.yaml.j2
+++ b/charms/argo-controller/src/templates/minio_configmap.yaml.j2
@@ -1,9 +1,11 @@
 apiVersion: v1
 data:
   artifactRepository: |
+    archiveLogs: true
     s3:
       endpoint: {{ s3_minio_endpoint }}
       bucket: {{ s3_bucket }}
+      # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: {{ kubelet_insecure }}
       accessKeySecret:
         name: {{ mlpipeline_minio_artifact_secret }}
@@ -11,10 +13,13 @@ data:
       secretKeySecret:
         name: {{ mlpipeline_minio_artifact_secret }}
         key: secretkey
-  containerRuntimeExecutor: {{ runtime_executor }}
   executor: |
     imagePullPolicy: IfNotPresent
 kind: ConfigMap
 metadata:
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'
+  labels:
+    application-crd-id: kubeflow-pipelines
   name: {{ argo_controller_configmap }}
   namespace: {{ namespace }}

--- a/charms/argo-controller/tests/unit/test_charm.py
+++ b/charms/argo-controller/tests/unit/test_charm.py
@@ -140,7 +140,7 @@ def test_kubernetes_created_method(
 
     # Assert
     # FIXME: why is it counting 50?
-    assert mocked_lightkube_client.apply.call_count == 50
+    assert mocked_lightkube_client.apply.call_count == 62
     assert isinstance(harness.charm.kubernetes_resources.status, ActiveStatus)
 
 


### PR DESCRIPTION
This commit bumps the oci-image to bring the 3.4 version, as well as updates to the CRDs to their corresponding versions.
It also removes the `executor` config option as changing the executor is no longer supported in upstream.

Fixes #166