### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track 3.3.10

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -62,7 +62,7 @@ jobs:
         provider: microk8s
         channel: 1.25-strict/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
         charmcraft-channel: latest/candidate
 
     - name: Build and test


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944