### PR TITLE
build, tests: bump charmed-kubeflow-chisme 0.4.0 -> 0.4.1

### DIFF
--- a/charms/argo-controller/requirements-integration.txt
+++ b/charms/argo-controller/requirements-integration.txt
@@ -36,7 +36,7 @@ cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.0
+charmed-kubeflow-chisme==0.4.1
     # via -r requirements-integration.in
 charset-normalizer==3.3.2
     # via requests


### PR DESCRIPTION
Build charmed-kubeflow-chisme for requirements-integration.txt.

Part of https://github.com/canonical/charmed-kubeflow-chisme/issues/104