### PR TITLE
build: add rust toolchain and other build packages

### DIFF
--- a/charms/argo-controller/charmcraft.yaml
+++ b/charms/argo-controller/charmcraft.yaml
@@ -12,3 +12,4 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]  # Fixes install of some packages
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]


### PR DESCRIPTION
Adding the rust toolchain and other dependencies to avoid issues at build time.

Part of canonical/bundle-kubeflow#989