### PR TITLE
ci(upload-charm): use charmcraft from latest/candidate in track/3.3.10

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,3 +91,4 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
+          charmcraft-channel: latest/candidate


### PR DESCRIPTION
Use charmcraft from latest/candidate in upload-charm in order to unify the channel used during integration tests and publishing.
Ref canonical/bundle-kubeflow#993