### PR TITLE
feat: Add terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -26,14 +26,6 @@ jobs:
         sudo apt install tox
     - run: tox -vve argo-controller-lint
 
-  terraform-checks:
-    name: Terraform
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
-    with:
-      charm-path: ./charms/argo-controller
-      model: kubeflow
-      channel: latest/edge
-
   unit:
     name: Unit Tests
     runs-on: ubuntu-20.04
@@ -44,6 +36,14 @@ jobs:
         sudo apt update
         sudo apt install tox
     - run: tox -vve argo-controller-unit
+
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: ./charms/argo-controller
+      model: kubeflow
+      channel: latest/edge
 
   integration:
     name: Integration Test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,6 +28,12 @@ jobs:
       uses: terraform-linters/setup-tflint@v4
     - run: tox -vve argo-controller-lint
 
+  terraform-fmt:
+    name: Format terraform
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v1.0.0
+    with:
+      working-directory: charms/argo-controller/terraform
+
   unit:
     name: Unit Tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,7 +28,7 @@ jobs:
 
   terraform-checks:
     name: Terraform
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-add-terraform-checks-reusable-workflow
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     with:
       charm-path: ./charms/argo-controller
       model: kubeflow

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -29,7 +29,7 @@ jobs:
     - run: tox -vve argo-controller-lint
 
   terraform-fmt:
-    name: Format terraform
+    name: Format Terraform
     uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v1.0.0
     with:
       working-directory: charms/argo-controller/terraform

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -39,6 +39,7 @@ jobs:
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-deploy.yaml@orfeas-k-add-terraform-reusable-workflow
     with:
       model: kubeflow
+      channel: latest/edge
       working-directory: charms/argo-controller/terraform
 
   unit:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@orfeas-k-update-linting
     secrets: inherit
     with:
       charm-path: ./charms/argo-controller
@@ -24,6 +24,8 @@ jobs:
     - run: |
         sudo apt update
         sudo apt install tox
+    - name: Setup TFLint
+      uses: terraform-linters/setup-tflint@v4
     - run: tox -vve argo-controller-lint
 
   unit:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,7 +28,7 @@ jobs:
 
   terraform-checks:
     name: Terraform
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-test-terraform-workflows
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-add-terraform-checks-reusable-workflow
     with:
       charm-path: ./charms/argo-controller
       model: kubeflow

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,7 +28,7 @@ jobs:
 
   terraform-checks:
     name: Terraform
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-add-terraform-checks-workflow
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-test-terraform-workflows
     with:
       charm-path: ./charms/argo-controller
       model: kubeflow

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,10 +28,17 @@ jobs:
       uses: terraform-linters/setup-tflint@v4
     - run: tox -vve argo-controller-lint
 
-  terraform-fmt:
-    name: Format Terraform
+  terraform-check:
+    name: Check Terraform
     uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v1.0.0
     with:
+      working-directory: charms/argo-controller/terraform
+
+  terraform-deploy:
+    name: Deploy Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-deploy.yaml@orfeas-k-add-terraform-reusable-workflow
+    with:
+      model: kubeflow
       working-directory: charms/argo-controller/terraform
 
   unit:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@orfeas-k-update-linting
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
     secrets: inherit
     with:
       charm-path: ./charms/argo-controller
@@ -24,23 +24,15 @@ jobs:
     - run: |
         sudo apt update
         sudo apt install tox
-    - name: Setup TFLint
-      uses: terraform-linters/setup-tflint@v4
     - run: tox -vve argo-controller-lint
 
-  terraform-check:
-    name: Check Terraform
-    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v1.0.0
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-add-terraform-checks-workflow
     with:
-      working-directory: charms/argo-controller/terraform
-
-  terraform-deploy:
-    name: Deploy Terraform
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-deploy.yaml@orfeas-k-add-terraform-reusable-workflow
-    with:
+      charm-path: charms/argo-controller
       model: kubeflow
       channel: latest/edge
-      working-directory: charms/argo-controller/terraform
 
   unit:
     name: Unit Tests

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Terraform
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@orfeas-k-add-terraform-checks-workflow
     with:
-      charm-path: charms/argo-controller
+      charm-path: ./charms/argo-controller
       model: kubeflow
       channel: latest/edge
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 operators/argo-controller/build
 .tox
 .idea
+venv/
+.terraform*
+*.tfstate*

--- a/charms/argo-controller/terraform/README.md
+++ b/charms/argo-controller/terraform/README.md
@@ -29,16 +29,16 @@ Upon applied, the module exports the following outputs:
 ## Usage
 
 ### Integrating in a higher-level module
-In order to use this module in a higher-level module, ensure that Terraform is aware of its `model` dependency by passing to the `model_name` input the value of the output `juju_model.<model_label>.name`. For example:
+In order to use this module in a higher-level module, ensure that Terraform is aware of its `juju_model` dependency by passing to the `model_name` input  a reference to the `juju_model` resource's name. For example:
 
 ```
-resource "juju_model" "kubeflow" {
+resource "juju_model" "testing" {
   name = kubeflow
 }
 
 module "argo-controller" {
   source = "<path-to-this-directory>"
-  model_name = juju_model.kubeflow.name
+  model_name = juju_model.testing.name
 }
 ```
 

--- a/charms/argo-controller/terraform/README.md
+++ b/charms/argo-controller/terraform/README.md
@@ -1,3 +1,50 @@
 # Terraform module for argo-controller
 
-This is a Terraform module facilitating the deployment of argo-controller charm, using the [Terraform juju provider](https://registry.terraform.io/providers/juju/juju/latest/docs).
+This is a Terraform module facilitating the deployment of argo-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(number) | Map of charm resources revisions | False |
+| `revision`| number | Revision number of the charm name | False |
+
+## Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+### Integrating in a higher-level module
+In order to use this module in a higher-level module, ensure that Terraform is aware of its `model` dependency by passing to the `model_name` input the value of the output `juju_model.<model_label>.name`. For example:
+
+```
+resource "juju_model" "kubeflow" {
+  name = kubeflow
+}
+
+module "argo-controller" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.kubeflow.name
+}
+```
+
+### Applying directly the module from the CLI
+Although not recommended, in order to apply the module directly from the CLI, ensure that a `juju` model has already been created and then manually use its name as the value of the `model_name` input. For example:
+```
+# check that there is a model called `kubeflow`
+terraform apply -var "model_name=kubeflow"
+```

--- a/charms/argo-controller/terraform/README.md
+++ b/charms/argo-controller/terraform/README.md
@@ -30,8 +30,10 @@ Upon applied, the module exports the following outputs:
 
 ## Usage
 
-### Integrating in a higher-level module
-In order to use this module in a higher-level module, ensure that Terraform is aware of its `juju_model` dependency by passing to the `model_name` input  a reference to the `juju_model` resource's name. For example:
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
 
 ```
 resource "juju_model" "testing" {
@@ -44,9 +46,15 @@ module "argo-controller" {
 }
 ```
 
-### Applying directly the module from the CLI
-Although not recommended, in order to apply the module directly from the CLI, ensure that a `juju` model has already been created and then manually use its name as the value of the `model_name` input. For example:
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
 ```
-# check that there is a model called `kubeflow`
-terraform apply -var "model_name=kubeflow"
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "argo-controller" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
 ```

--- a/charms/argo-controller/terraform/README.md
+++ b/charms/argo-controller/terraform/README.md
@@ -1,0 +1,3 @@
+# Terraform module for argo-controller
+
+This is a Terraform module facilitating the deployment of argo-controller charm, using the [Terraform juju provider](https://registry.terraform.io/providers/juju/juju/latest/docs).

--- a/charms/argo-controller/terraform/README.md
+++ b/charms/argo-controller/terraform/README.md
@@ -5,7 +5,9 @@ This is a Terraform module facilitating the deployment of argo-controller charm,
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 
-## Inputs
+## API
+
+### Inputs
 The module offers the following configurable inputs:
 
 | Name | Type | Description | Required |
@@ -17,7 +19,7 @@ The module offers the following configurable inputs:
 | `resources`| map(number) | Map of charm resources revisions | False |
 | `revision`| number | Revision number of the charm name | False |
 
-## Outputs
+### Outputs
 Upon applied, the module exports the following outputs:
 
 | Name | Description |

--- a/charms/argo-controller/terraform/main.tf
+++ b/charms/argo-controller/terraform/main.tf
@@ -4,10 +4,10 @@ resource "juju_application" "argo_controller" {
     channel  = var.channel
     revision = var.revision
   }
-  config = var.config
+  config    = var.config
   model     = var.model_name
   name      = var.app_name
   resources = var.resources
   trust     = true
-  units  = 1
+  units     = 1
 }

--- a/charms/argo-controller/terraform/main.tf
+++ b/charms/argo-controller/terraform/main.tf
@@ -1,13 +1,13 @@
 resource "juju_application" "argo_controller" {
-  name      = var.app_name
-  model     = var.model_name
-  trust     = true
-  resources = var.resources
   charm {
     name     = "argo-controller"
     channel  = var.channel
     revision = var.revision
   }
-  units  = 1
   config = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units  = 1
 }

--- a/charms/argo-controller/terraform/main.tf
+++ b/charms/argo-controller/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "argo_controller" {
+  name      = var.app_name
+  model     = var.model_name
+  trust     = true
+  resources = var.resources
+  charm {
+    name     = "argo-controller"
+    channel  = var.channel
+    revision = var.revision
+  }
+  units  = 1
+  config = var.config
+}

--- a/charms/argo-controller/terraform/outputs.tf
+++ b/charms/argo-controller/terraform/outputs.tf
@@ -1,0 +1,17 @@
+output "app_name" {
+  value = juju_application.argo_controller.name
+}
+
+output "provides" {
+  value = [
+    "metrics-endpoint",
+    "grafana-dashboard"
+  ]
+}
+
+output "requires" {
+  value = [
+    "object-storage",
+    "logging"
+  ]
+}

--- a/charms/argo-controller/terraform/outputs.tf
+++ b/charms/argo-controller/terraform/outputs.tf
@@ -3,15 +3,15 @@ output "app_name" {
 }
 
 output "provides" {
-  value = [
-    "metrics-endpoint",
-    "grafana-dashboard"
-  ]
+  value = {
+    metrics_endpoint  = "metrics-endpoint",
+    grafana_dashboard = "grafana-dashboard"
+  }
 }
 
 output "requires" {
-  value = [
-    "object-storage",
-    "logging"
-  ]
+  value = {
+    object_storage = "object-storage",
+    logging        = "logging"
+  }
 }

--- a/charms/argo-controller/terraform/variables.tf
+++ b/charms/argo-controller/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "argo-controller"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources revisions"
+  type        = map(number)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/argo-controller/terraform/variables.tf
+++ b/charms/argo-controller/terraform/variables.tf
@@ -21,6 +21,7 @@ variable "model_name" {
   type        = string
 }
 
+# TODO: Update to a map of strings, once juju provider 0.14 is released
 variable "resources" {
   description = "Map of resources revisions"
   type        = map(number)

--- a/charms/argo-controller/terraform/versions.tf
+++ b/charms/argo-controller/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.6"
   required_providers {
     juju = {
       source  = "juju/juju"

--- a/charms/argo-controller/terraform/versions.tf
+++ b/charms/argo-controller/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.13.0"
+    }
+  }
+}

--- a/charms/argo-controller/tox.ini
+++ b/charms/argo-controller/tox.ini
@@ -60,7 +60,6 @@ commands =
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
-    tflint --chdir=terraform --recursive
 deps =
     -r requirements-lint.txt
 description = Check code against coding style standards

--- a/charms/argo-controller/tox.ini
+++ b/charms/argo-controller/tox.ini
@@ -49,6 +49,8 @@ deps =
 description = Apply coding style standards to code
 
 [testenv:lint]
+allowlist_externals =
+    tflint
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
@@ -60,6 +62,7 @@ commands =
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
+    tflint --chdir=terraform --recursive
 deps =
     -r requirements-lint.txt
 description = Check code against coding style standards

--- a/charms/argo-controller/tox.ini
+++ b/charms/argo-controller/tox.ini
@@ -49,8 +49,6 @@ deps =
 description = Apply coding style standards to code
 
 [testenv:lint]
-allowlist_externals =
-    tflint
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
@@ -66,6 +64,13 @@ commands =
 deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
+
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
 
 [testenv:unit]
 commands =


### PR DESCRIPTION
Adds a terraform module, as designed in [CC006 - Terraform modules organization in the Juju ecosystem](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit) spec. The module facilitates the deployment of `argo-controller` charm, using the [Terraform juju provider](https://registry.terraform.io/providers/juju/juju/latest/docs).


Since the spec is not finalized yet, the PR may miss features/decisions that are still under discussion.

#### Parts where we deviate from the spec
* Omitted `units` from variables (inputs). This is because CKF charms have not been designed to function with more than one units.

#### Decisions that are still under discussion in the spec
* ~~`outputs.tf` and `variables.tf` are (and should be) in alphabetical order as per [Terraform style guide](https://developer.hashicorp.com/terraform/language/style#file-names).~~
* ~~outputs `provides` and `requires` endpoints.~~
* variable `channel` has `null` as default value to replicate native `juju` behaviour, which also asks Charmhub about the default channel, if it's not provided. The spec leaves that up to the developers.
* variable `app_name` has a default value, same as the one in `juju_application.argo_controller.charm.name`. This is because `juju deploy` native behavior uses the `charm.name` as the application name, if none is provided. 

#### Additional implementation notes
* `.gitignore`: I added things that didn't need to be commited. Not 100% sure this covers everything.
#### CI
Regarding the CI, there is a [comment in the spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?disco=AAABU9k_0DI) by Ghislain where he mentioned that "the first implementation steps for this spec will be to create shared workflows". Thus, I think we shouldn't block too much on the CI right now. I 'd prefer if we removed it completely than spend too much time reviewing it, since it will change in the future. That being said, here are the implementation details about it.
* This is to be merged after https://github.com/canonical/charmed-kubeflow-workflows/pull/58. I updated there the lint job in order to install `tflint`, which cannot be installed as a pip dependency.
* For running `terraform fmt` and `terraform validate`,  we are using Telco team's [reusable workflow](https://github.com/canonical/sdcore-github-workflows/blob/main/.github/workflows/terraform.yaml) . An example of its usage can be found [here](https://github.com/canonical/terraform-juju-sdcore/blob/9067b8baac96486f76854990cb82712eb88b72a0/.github/workflows/terraform.yaml#L19)).
* CI is using reusable workflow to deploy terraform module from https://github.com/canonical/charmed-kubeflow-workflows/pull/59

Closes #196

### Referenced work
* https://github.com/canonical/mimir-worker-k8s-operator/pull/74
* https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-control-plane-k8s

### (optional) TO DO
- [x] Create a reusable workflow under `charmed-kubeflow-workflows` similar to https://github.com/canonical/sunbeam-terraform/blob/main/.github/workflows/deploy.yml in order to make a simple deployment using the module

## Testing
The terraform can be used with a `terraform apply` like the one below, using only the arguments that are needed.
```
terraform apply -var "app_name=argoo" -var "channel=3.4/stable" -var "model_name=kubeflow" -var "resources={oci-image: 3}"
``` 