### PR TITLE
fix: set keyFormat in controller ConfigMap (#208)

### DIFF
--- a/charms/argo-controller/src/charm.py
+++ b/charms/argo-controller/src/charm.py
@@ -28,6 +28,7 @@ from ops.main import main
 
 from components.pebble_component import (
     ARGO_CONTROLLER_CONFIGMAP,
+    ARGO_KEYFORMAT,
     METRICS_PORT,
     ArgoControllerPebbleService,
 )
@@ -154,6 +155,7 @@ class ArgoControllerOperator(CharmBase):
                 f"{self.object_storage_relation.component.get_data()['port']}"
             ),
             "kubelet_insecure": self.model.config["kubelet-insecure"],
+            "key_format": ARGO_KEYFORMAT,
         }
 
 

--- a/charms/argo-controller/src/components/pebble_component.py
+++ b/charms/argo-controller/src/components/pebble_component.py
@@ -8,6 +8,13 @@ from ops.pebble import Layer
 logger = logging.getLogger(__name__)
 
 ARGO_CONTROLLER_CONFIGMAP = "argo-workflow-controller-configmap"
+ARGO_KEYFORMAT = (
+    "artifacts/{{workflow.name}}/"
+    "{{workflow.creationTimestamp.Y}}/"
+    "{{workflow.creationTimestamp.m}}/"
+    "{{workflow.creationTimestamp.d}}/"
+    "{{pod.name}}"
+)
 EXECUTOR_IMAGE_CONFIG_NAME = "executor-image"
 LIVENESS_PROBE_PORT = "6060"
 METRICS_PORT = "9090"

--- a/charms/argo-controller/src/templates/minio_configmap.yaml.j2
+++ b/charms/argo-controller/src/templates/minio_configmap.yaml.j2
@@ -5,6 +5,8 @@ data:
     s3:
       endpoint: {{ s3_minio_endpoint }}
       bucket: {{ s3_bucket }}
+      # keyFormat defines how artifacts will be organized in a bucket.
+      keyFormat: {{ key_format }}
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS
       insecure: {{ kubelet_insecure }}
       accessKeySecret:


### PR DESCRIPTION
Backports #208 to `track/3.4`, the fix necessary for https://github.com/canonical/kfp-operators/issues/582
Part of KFP 2.3 changes
After the on push for this PR succeeds, the charm should be promoted to stable