### PR TITLE
backport: CI + dependency updates

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -52,7 +52,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.29-strict/stable
+        channel: 1.31-strict/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
         juju-channel: 3.6/stable
         charmcraft-channel: 3.x/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,8 +58,8 @@ jobs:
         provider: microk8s
         channel: 1.29-strict/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
-        juju-channel: 3.4/stable
-        charmcraft-channel: latest/candidate
+        juju-channel: 3.6/stable
+        charmcraft-channel: 3.x/stable
 
     - name: Build and test
       working-directory: ./charms/${{ matrix.charm }}

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -21,9 +21,7 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
-    - run: |
-        sudo apt update
-        sudo apt install tox
+    - run: pip install tox
     - run: tox -vve argo-controller-lint
 
   unit:
@@ -32,9 +30,7 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
-    - run: |
-        sudo apt update
-        sudo apt install tox
+    - run: pip install tox
     - run: tox -vve argo-controller-unit
 
   terraform-checks:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,4 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.x/stable

--- a/charms/argo-controller/charmcraft.yaml
+++ b/charms/argo-controller/charmcraft.yaml
@@ -12,3 +12,9 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]  # Fixes install of some packages
+    # Following lines are needed due to https://github.com/canonical/charmcraft/issues/1722
+    build-snaps: [rustup]
+    build-packages: [pkg-config, libffi-dev, libssl-dev]
+    override-build: |
+      rustup default stable
+      craftctl default

--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -12,7 +12,7 @@ options:
     description: S3 key prefix
   executor-image:
     type: string
-    default: charmedkubeflow/argoexec:3.4.16-ffcffa9
+    default: gcr.io/ml-pipeline/argoexec:v3.4.17-license-compliance
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:

--- a/charms/argo-controller/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/charms/argo-controller/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -157,7 +157,7 @@ by adding itself as an observer for these events:
         self._on_dashboards_changed,
     )
 
-Dashboards can be retrieved the :meth:`dashboards`:
+Dashboards can be retrieved via the `dashboards` method:
 
 It will be returned in the format of:
 
@@ -175,7 +175,6 @@ It will be returned in the format of:
 The consuming charm should decompress the dashboard.
 """
 
-import base64
 import hashlib
 import json
 import logging
@@ -187,7 +186,7 @@ import subprocess
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 from ops.charm import (
@@ -209,6 +208,7 @@ from ops.framework import (
     StoredState,
 )
 from ops.model import Relation
+from cosl import LZMABase64
 
 # The unique Charmhub library identifier, never change it
 LIBID = "c49eb9c7dfef40c7b6235ebd67010a3f"
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 35
+LIBPATCH = 37
 
 logger = logging.getLogger(__name__)
 
@@ -544,357 +544,351 @@ def _validate_relation_by_interface_and_direction(
         raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
 
-def _encode_dashboard_content(content: Union[str, bytes]) -> str:
-    if isinstance(content, str):
-        content = bytes(content, "utf-8")
+class CharmedDashboard:
+    """A helper class for handling dashboards on the requirer (Grafana) side."""
 
-    return base64.b64encode(lzma.compress(content)).decode("utf-8")
+    @classmethod
+    def _convert_dashboard_fields(cls, content: str, inject_dropdowns: bool = True) -> str:
+        """Make sure values are present for Juju topology.
 
+        Inserts Juju topology variables and selectors into the template, as well as
+        a variable for Prometheus.
+        """
+        dict_content = json.loads(content)
+        datasources = {}
+        existing_templates = False
 
-def _decode_dashboard_content(encoded_content: str) -> str:
-    return lzma.decompress(base64.b64decode(encoded_content.encode("utf-8"))).decode()
+        template_dropdowns = (
+            TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS  # type: ignore
+            if inject_dropdowns
+            else DATASOURCE_TEMPLATE_DROPDOWNS
+        )
 
+        # If the dashboard has __inputs, get the names to replace them. These are stripped
+        # from reactive dashboards in GrafanaDashboardAggregator, but charm authors in
+        # newer charms may import them directly from the marketplace
+        if "__inputs" in dict_content:
+            for field in dict_content["__inputs"]:
+                if "type" in field and field["type"] == "datasource":
+                    datasources[field["name"]] = field["pluginName"].lower()
+            del dict_content["__inputs"]
 
-def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> str:
-    """Make sure values are present for Juju topology.
-
-    Inserts Juju topology variables and selectors into the template, as well as
-    a variable for Prometheus.
-    """
-    dict_content = json.loads(content)
-    datasources = {}
-    existing_templates = False
-
-    template_dropdowns = (
-        TOPOLOGY_TEMPLATE_DROPDOWNS + DATASOURCE_TEMPLATE_DROPDOWNS  # type: ignore
-        if inject_dropdowns
-        else DATASOURCE_TEMPLATE_DROPDOWNS
-    )
-
-    # If the dashboard has __inputs, get the names to replace them. These are stripped
-    # from reactive dashboards in GrafanaDashboardAggregator, but charm authors in
-    # newer charms may import them directly from the marketplace
-    if "__inputs" in dict_content:
-        for field in dict_content["__inputs"]:
-            if "type" in field and field["type"] == "datasource":
-                datasources[field["name"]] = field["pluginName"].lower()
-        del dict_content["__inputs"]
-
-    # If no existing template variables exist, just insert our own
-    if "templating" not in dict_content:
-        dict_content["templating"] = {"list": list(template_dropdowns)}  # type: ignore
-    else:
-        # Otherwise, set a flag so we can go back later
-        existing_templates = True
-        for template_value in dict_content["templating"]["list"]:
-            # Build a list of `datasource_name`: `datasource_type` mappings
-            # The "query" field is actually "prometheus", "loki", "influxdb", etc
-            if "type" in template_value and template_value["type"] == "datasource":
-                datasources[template_value["name"]] = template_value["query"].lower()
-
-        # Put our own variables in the template
-        for d in template_dropdowns:  # type: ignore
-            if d not in dict_content["templating"]["list"]:
-                dict_content["templating"]["list"].insert(0, d)
-
-    dict_content = _replace_template_fields(dict_content, datasources, existing_templates)
-    return json.dumps(dict_content)
-
-
-def _replace_template_fields(  # noqa: C901
-    dict_content: dict, datasources: dict, existing_templates: bool
-) -> dict:
-    """Make templated fields get cleaned up afterwards.
-
-    If existing datasource variables are present, try to substitute them.
-    """
-    replacements = {"loki": "${lokids}", "prometheus": "${prometheusds}"}
-    used_replacements = []  # type: List[str]
-
-    # If any existing datasources match types we know, or we didn't find
-    # any templating variables at all, template them.
-    if datasources or not existing_templates:
-        panels = dict_content.get("panels", {})
-        if panels:
-            dict_content["panels"] = _template_panels(
-                panels, replacements, used_replacements, existing_templates, datasources
-            )
-
-        # Find panels nested under rows
-        rows = dict_content.get("rows", {})
-        if rows:
-            for row_idx, row in enumerate(rows):
-                if "panels" in row.keys():
-                    rows[row_idx]["panels"] = _template_panels(
-                        row["panels"],
-                        replacements,
-                        used_replacements,
-                        existing_templates,
-                        datasources,
-                    )
-
-            dict_content["rows"] = rows
-
-    # Finally, go back and pop off the templates we stubbed out
-    deletions = []
-    for tmpl in dict_content["templating"]["list"]:
-        if tmpl["name"] and tmpl["name"] in used_replacements:
-            deletions.append(tmpl)
-
-    for d in deletions:
-        dict_content["templating"]["list"].remove(d)
-
-    return dict_content
-
-
-def _template_panels(
-    panels: dict,
-    replacements: dict,
-    used_replacements: list,
-    existing_templates: bool,
-    datasources: dict,
-) -> dict:
-    """Iterate through a `panels` object and template it appropriately."""
-    # Go through all the panels. If they have a datasource set, AND it's one
-    # that we can convert to ${lokids} or ${prometheusds}, by stripping off the
-    # ${} templating and comparing the name to the list we built, replace it,
-    # otherwise, leave it alone.
-    #
-    for panel in panels:
-        if "datasource" not in panel or not panel.get("datasource"):
-            continue
-        if not existing_templates:
-            datasource = panel.get("datasource")
-            if isinstance(datasource, str):
-                if "loki" in datasource:
-                    panel["datasource"] = "${lokids}"
-                elif "grafana" in datasource:
-                    continue
-                else:
-                    panel["datasource"] = "${prometheusds}"
-            elif isinstance(datasource, dict):
-                # In dashboards exported by Grafana 9, datasource type is dict
-                dstype = datasource.get("type", "")
-                if dstype == "loki":
-                    panel["datasource"]["uid"] = "${lokids}"
-                elif dstype == "prometheus":
-                    panel["datasource"]["uid"] = "${prometheusds}"
-                else:
-                    logger.debug("Unrecognized datasource type '%s'; skipping", dstype)
-                    continue
-            else:
-                logger.error("Unknown datasource format: skipping")
-                continue
+        # If no existing template variables exist, just insert our own
+        if "templating" not in dict_content:
+            dict_content["templating"] = {"list": list(template_dropdowns)}  # type: ignore
         else:
-            if isinstance(panel["datasource"], str):
-                if panel["datasource"].lower() in replacements.values():
-                    # Already a known template variable
-                    continue
-                # Strip out variable characters and maybe braces
-                ds = re.sub(r"(\$|\{|\})", "", panel["datasource"])
+            # Otherwise, set a flag so we can go back later
+            existing_templates = True
+            for template_value in dict_content["templating"]["list"]:
+                # Build a list of `datasource_name`: `datasource_type` mappings
+                # The "query" field is actually "prometheus", "loki", "influxdb", etc
+                if "type" in template_value and template_value["type"] == "datasource":
+                    datasources[template_value["name"]] = template_value["query"].lower()
 
-                if ds not in datasources.keys():
-                    # Unknown, non-templated datasource, potentially a Grafana builtin
-                    continue
+            # Put our own variables in the template
+            for d in template_dropdowns:  # type: ignore
+                if d not in dict_content["templating"]["list"]:
+                    dict_content["templating"]["list"].insert(0, d)
 
-                replacement = replacements.get(datasources[ds], "")
-                if replacement:
-                    used_replacements.append(ds)
-                panel["datasource"] = replacement or panel["datasource"]
-            elif isinstance(panel["datasource"], dict):
-                dstype = panel["datasource"].get("type", "")
-                if panel["datasource"].get("uid", "").lower() in replacements.values():
-                    # Already a known template variable
-                    continue
-                # Strip out variable characters and maybe braces
-                ds = re.sub(r"(\$|\{|\})", "", panel["datasource"].get("uid", ""))
-
-                if ds not in datasources.keys():
-                    # Unknown, non-templated datasource, potentially a Grafana builtin
-                    continue
-
-                replacement = replacements.get(datasources[ds], "")
-                if replacement:
-                    used_replacements.append(ds)
-                    panel["datasource"]["uid"] = replacement
-            else:
-                logger.error("Unknown datasource format: skipping")
-                continue
-    return panels
-
-
-def _inject_labels(content: str, topology: dict, transformer: "CosTool") -> str:
-    """Inject Juju topology into panel expressions via CosTool.
-
-    A dashboard will have a structure approximating:
-        {
-            "__inputs": [],
-            "templating": {
-                "list": [
-                    {
-                        "name": "prometheusds",
-                        "type": "prometheus"
-                    }
-                ]
-            },
-            "panels": [
-                {
-                    "foo": "bar",
-                    "targets": [
-                        {
-                            "some": "field",
-                            "expr": "up{job="foo"}"
-                        },
-                        {
-                            "some_other": "field",
-                            "expr": "sum(http_requests_total{instance="$foo"}[5m])}
-                        }
-                    ],
-                    "datasource": "${someds}"
-                }
-            ]
-        }
-
-    `templating` is used elsewhere in this library, but the structure is not rigid. It is
-    not guaranteed that a panel will actually have any targets (it could be a "spacer" with
-    no datasource, hence no expression). It could have only one target. It could have multiple
-    targets. It could have multiple targets of which only one has an `expr` to evaluate. We need
-    to try to handle all of these concisely.
-
-    `cos-tool` (`github.com/canonical/cos-tool` as a Go module in general)
-    does not know "Grafana-isms", such as using `[$_variable]` to modify the query from the user
-    interface, so we add placeholders (as `5y`, since it must parse, but a dashboard looking for
-    five years for a panel query would be unusual).
-
-    Args:
-        content: dashboard content as a string
-        topology: a dict containing topology values
-        transformer: a 'CosTool' instance
-    Returns:
-        dashboard content with replaced values.
-    """
-    dict_content = json.loads(content)
-
-    if "panels" not in dict_content.keys():
+        dict_content = cls._replace_template_fields(dict_content, datasources, existing_templates)
         return json.dumps(dict_content)
 
-    # Go through all the panels and inject topology labels
-    # Panels may have more than one 'target' where the expressions live, so that must be
-    # accounted for. Additionally, `promql-transform` does not necessarily gracefully handle
-    # expressions with range queries including variables. Exclude these.
-    #
-    # It is not a certainty that the `datasource` field will necessarily reflect the type, so
-    # operate on all fields.
-    panels = dict_content["panels"]
-    topology_with_prefix = {"juju_{}".format(k): v for k, v in topology.items()}
+    @classmethod
+    def _replace_template_fields(  # noqa: C901
+        cls, dict_content: dict, datasources: dict, existing_templates: bool
+    ) -> dict:
+        """Make templated fields get cleaned up afterwards.
 
-    # We need to use an index so we can insert the changed element back later
-    for panel_idx, panel in enumerate(panels):
-        if not isinstance(panel, dict):
-            continue
+        If existing datasource variables are present, try to substitute them.
+        """
+        replacements = {"loki": "${lokids}", "prometheus": "${prometheusds}"}
+        used_replacements = []  # type: List[str]
 
-        # Use the index to insert it back in the same location
-        panels[panel_idx] = _modify_panel(panel, topology_with_prefix, transformer)
+        # If any existing datasources match types we know, or we didn't find
+        # any templating variables at all, template them.
+        if datasources or not existing_templates:
+            panels = dict_content.get("panels", {})
+            if panels:
+                dict_content["panels"] = cls._template_panels(
+                    panels, replacements, used_replacements, existing_templates, datasources
+                )
 
-    return json.dumps(dict_content)
+            # Find panels nested under rows
+            rows = dict_content.get("rows", {})
+            if rows:
+                for row_idx, row in enumerate(rows):
+                    if "panels" in row.keys():
+                        rows[row_idx]["panels"] = cls._template_panels(
+                            row["panels"],
+                            replacements,
+                            used_replacements,
+                            existing_templates,
+                            datasources,
+                        )
 
+                dict_content["rows"] = rows
 
-def _modify_panel(panel: dict, topology: dict, transformer: "CosTool") -> dict:
-    """Inject Juju topology into panel expressions via CosTool.
+        # Finally, go back and pop off the templates we stubbed out
+        deletions = []
+        for tmpl in dict_content["templating"]["list"]:
+            if tmpl["name"] and tmpl["name"] in used_replacements:
+                deletions.append(tmpl)
 
-    Args:
-        panel: a dashboard panel as a dict
-        topology: a dict containing topology values
-        transformer: a 'CosTool' instance
-    Returns:
-        the panel with injected values
-    """
-    if "targets" not in panel.keys():
+        for d in deletions:
+            dict_content["templating"]["list"].remove(d)
+
+        return dict_content
+
+    @classmethod
+    def _template_panels(
+        cls,
+        panels: dict,
+        replacements: dict,
+        used_replacements: list,
+        existing_templates: bool,
+        datasources: dict,
+    ) -> dict:
+        """Iterate through a `panels` object and template it appropriately."""
+        # Go through all the panels. If they have a datasource set, AND it's one
+        # that we can convert to ${lokids} or ${prometheusds}, by stripping off the
+        # ${} templating and comparing the name to the list we built, replace it,
+        # otherwise, leave it alone.
+        #
+        for panel in panels:
+            if "datasource" not in panel or not panel.get("datasource"):
+                continue
+            if not existing_templates:
+                datasource = panel.get("datasource")
+                if isinstance(datasource, str):
+                    if "loki" in datasource:
+                        panel["datasource"] = "${lokids}"
+                    elif "grafana" in datasource:
+                        continue
+                    else:
+                        panel["datasource"] = "${prometheusds}"
+                elif isinstance(datasource, dict):
+                    # In dashboards exported by Grafana 9, datasource type is dict
+                    dstype = datasource.get("type", "")
+                    if dstype == "loki":
+                        panel["datasource"]["uid"] = "${lokids}"
+                    elif dstype == "prometheus":
+                        panel["datasource"]["uid"] = "${prometheusds}"
+                    else:
+                        logger.debug("Unrecognized datasource type '%s'; skipping", dstype)
+                        continue
+                else:
+                    logger.error("Unknown datasource format: skipping")
+                    continue
+            else:
+                if isinstance(panel["datasource"], str):
+                    if panel["datasource"].lower() in replacements.values():
+                        # Already a known template variable
+                        continue
+                    # Strip out variable characters and maybe braces
+                    ds = re.sub(r"(\$|\{|\})", "", panel["datasource"])
+
+                    if ds not in datasources.keys():
+                        # Unknown, non-templated datasource, potentially a Grafana builtin
+                        continue
+
+                    replacement = replacements.get(datasources[ds], "")
+                    if replacement:
+                        used_replacements.append(ds)
+                    panel["datasource"] = replacement or panel["datasource"]
+                elif isinstance(panel["datasource"], dict):
+                    dstype = panel["datasource"].get("type", "")
+                    if panel["datasource"].get("uid", "").lower() in replacements.values():
+                        # Already a known template variable
+                        continue
+                    # Strip out variable characters and maybe braces
+                    ds = re.sub(r"(\$|\{|\})", "", panel["datasource"].get("uid", ""))
+
+                    if ds not in datasources.keys():
+                        # Unknown, non-templated datasource, potentially a Grafana builtin
+                        continue
+
+                    replacement = replacements.get(datasources[ds], "")
+                    if replacement:
+                        used_replacements.append(ds)
+                        panel["datasource"]["uid"] = replacement
+                else:
+                    logger.error("Unknown datasource format: skipping")
+                    continue
+        return panels
+
+    @classmethod
+    def _inject_labels(cls, content: str, topology: dict, transformer: "CosTool") -> str:
+        """Inject Juju topology into panel expressions via CosTool.
+
+        A dashboard will have a structure approximating:
+            {
+                "__inputs": [],
+                "templating": {
+                    "list": [
+                        {
+                            "name": "prometheusds",
+                            "type": "prometheus"
+                        }
+                    ]
+                },
+                "panels": [
+                    {
+                        "foo": "bar",
+                        "targets": [
+                            {
+                                "some": "field",
+                                "expr": "up{job="foo"}"
+                            },
+                            {
+                                "some_other": "field",
+                                "expr": "sum(http_requests_total{instance="$foo"}[5m])}
+                            }
+                        ],
+                        "datasource": "${someds}"
+                    }
+                ]
+            }
+
+        `templating` is used elsewhere in this library, but the structure is not rigid. It is
+        not guaranteed that a panel will actually have any targets (it could be a "spacer" with
+        no datasource, hence no expression). It could have only one target. It could have multiple
+        targets. It could have multiple targets of which only one has an `expr` to evaluate. We need
+        to try to handle all of these concisely.
+
+        `cos-tool` (`github.com/canonical/cos-tool` as a Go module in general)
+        does not know "Grafana-isms", such as using `[$_variable]` to modify the query from the user
+        interface, so we add placeholders (as `5y`, since it must parse, but a dashboard looking for
+        five years for a panel query would be unusual).
+
+        Args:
+            content: dashboard content as a string
+            topology: a dict containing topology values
+            transformer: a 'CosTool' instance
+        Returns:
+            dashboard content with replaced values.
+        """
+        dict_content = json.loads(content)
+
+        if "panels" not in dict_content.keys():
+            return json.dumps(dict_content)
+
+        # Go through all the panels and inject topology labels
+        # Panels may have more than one 'target' where the expressions live, so that must be
+        # accounted for. Additionally, `promql-transform` does not necessarily gracefully handle
+        # expressions with range queries including variables. Exclude these.
+        #
+        # It is not a certainty that the `datasource` field will necessarily reflect the type, so
+        # operate on all fields.
+        panels = dict_content["panels"]
+        topology_with_prefix = {"juju_{}".format(k): v for k, v in topology.items()}
+
+        # We need to use an index so we can insert the changed element back later
+        for panel_idx, panel in enumerate(panels):
+            if not isinstance(panel, dict):
+                continue
+
+            # Use the index to insert it back in the same location
+            panels[panel_idx] = cls._modify_panel(panel, topology_with_prefix, transformer)
+
+        return json.dumps(dict_content)
+
+    @classmethod
+    def _modify_panel(cls, panel: dict, topology: dict, transformer: "CosTool") -> dict:
+        """Inject Juju topology into panel expressions via CosTool.
+
+        Args:
+            panel: a dashboard panel as a dict
+            topology: a dict containing topology values
+            transformer: a 'CosTool' instance
+        Returns:
+            the panel with injected values
+        """
+        if "targets" not in panel.keys():
+            return panel
+
+        # Pre-compile a regular expression to grab values from inside of []
+        range_re = re.compile(r"\[(?P<value>.*?)\]")
+        # Do the same for any offsets
+        offset_re = re.compile(r"offset\s+(?P<value>-?\s*[$\w]+)")
+
+        known_datasources = {"${prometheusds}": "promql", "${lokids}": "logql"}
+
+        targets = panel["targets"]
+
+        # We need to use an index so we can insert the changed element back later
+        for idx, target in enumerate(targets):
+            # If there's no expression, we don't need to do anything
+            if "expr" not in target.keys():
+                continue
+            expr = target["expr"]
+
+            if "datasource" not in panel.keys():
+                continue
+
+            if isinstance(panel["datasource"], str):
+                if panel["datasource"] not in known_datasources:
+                    continue
+                querytype = known_datasources[panel["datasource"]]
+            elif isinstance(panel["datasource"], dict):
+                if panel["datasource"]["uid"] not in known_datasources:
+                    continue
+                querytype = known_datasources[panel["datasource"]["uid"]]
+            else:
+                logger.error("Unknown datasource format: skipping")
+                continue
+
+            # Capture all values inside `[]` into a list which we'll iterate over later to
+            # put them back in-order. Then apply the regex again and replace everything with
+            # `[5y]` so promql/parser will take it.
+            #
+            # Then do it again for offsets
+            range_values = [m.group("value") for m in range_re.finditer(expr)]
+            expr = range_re.sub(r"[5y]", expr)
+
+            offset_values = [m.group("value") for m in offset_re.finditer(expr)]
+            expr = offset_re.sub(r"offset 5y", expr)
+            # Retrieve the new expression (which may be unchanged if there were no label
+            # matchers in the expression, or if tt was unable to be parsed like logql. It's
+            # virtually impossible to tell from any datasource "name" in a panel what the
+            # actual type is without re-implementing a complete dashboard parser, but no
+            # harm will some from passing invalid promql -- we'll just get the original back.
+            #
+            replacement = transformer.inject_label_matchers(expr, topology, querytype)
+
+            if replacement == target["expr"]:
+                # promql-transform caught an error. Move on
+                continue
+
+            # Go back and substitute values in [] which were pulled out
+            # Enumerate with an index... again. The same regex is ok, since it will still match
+            # `[(.*?)]`, which includes `[5y]`, our placeholder
+            for i, match in enumerate(range_re.finditer(replacement)):
+                # Replace one-by-one, starting from the left. We build the string back with
+                # `str.replace(string_to_replace, replacement_value, count)`. Limit the count
+                # to one, since we are going through one-by-one through the list we saved earlier
+                # in `range_values`.
+                replacement = replacement.replace(
+                    "[{}]".format(match.group("value")),
+                    "[{}]".format(range_values[i]),
+                    1,
+                )
+
+            for i, match in enumerate(offset_re.finditer(replacement)):
+                # Replace one-by-one, starting from the left. We build the string back with
+                # `str.replace(string_to_replace, replacement_value, count)`. Limit the count
+                # to one, since we are going through one-by-one through the list we saved earlier
+                # in `range_values`.
+                replacement = replacement.replace(
+                    "offset {}".format(match.group("value")),
+                    "offset {}".format(offset_values[i]),
+                    1,
+                )
+
+            # Use the index to insert it back in the same location
+            targets[idx]["expr"] = replacement
+
+        panel["targets"] = targets
         return panel
-
-    # Pre-compile a regular expression to grab values from inside of []
-    range_re = re.compile(r"\[(?P<value>.*?)\]")
-    # Do the same for any offsets
-    offset_re = re.compile(r"offset\s+(?P<value>-?\s*[$\w]+)")
-
-    known_datasources = {"${prometheusds}": "promql", "${lokids}": "logql"}
-
-    targets = panel["targets"]
-
-    # We need to use an index so we can insert the changed element back later
-    for idx, target in enumerate(targets):
-        # If there's no expression, we don't need to do anything
-        if "expr" not in target.keys():
-            continue
-        expr = target["expr"]
-
-        if "datasource" not in panel.keys():
-            continue
-
-        if isinstance(panel["datasource"], str):
-            if panel["datasource"] not in known_datasources:
-                continue
-            querytype = known_datasources[panel["datasource"]]
-        elif isinstance(panel["datasource"], dict):
-            if panel["datasource"]["uid"] not in known_datasources:
-                continue
-            querytype = known_datasources[panel["datasource"]["uid"]]
-        else:
-            logger.error("Unknown datasource format: skipping")
-            continue
-
-        # Capture all values inside `[]` into a list which we'll iterate over later to
-        # put them back in-order. Then apply the regex again and replace everything with
-        # `[5y]` so promql/parser will take it.
-        #
-        # Then do it again for offsets
-        range_values = [m.group("value") for m in range_re.finditer(expr)]
-        expr = range_re.sub(r"[5y]", expr)
-
-        offset_values = [m.group("value") for m in offset_re.finditer(expr)]
-        expr = offset_re.sub(r"offset 5y", expr)
-        # Retrieve the new expression (which may be unchanged if there were no label
-        # matchers in the expression, or if tt was unable to be parsed like logql. It's
-        # virtually impossible to tell from any datasource "name" in a panel what the
-        # actual type is without re-implementing a complete dashboard parser, but no
-        # harm will some from passing invalid promql -- we'll just get the original back.
-        #
-        replacement = transformer.inject_label_matchers(expr, topology, querytype)
-
-        if replacement == target["expr"]:
-            # promql-tranform caught an error. Move on
-            continue
-
-        # Go back and substitute values in [] which were pulled out
-        # Enumerate with an index... again. The same regex is ok, since it will still match
-        # `[(.*?)]`, which includes `[5y]`, our placeholder
-        for i, match in enumerate(range_re.finditer(replacement)):
-            # Replace one-by-one, starting from the left. We build the string back with
-            # `str.replace(string_to_replace, replacement_value, count)`. Limit the count
-            # to one, since we are going through one-by-one through the list we saved earlier
-            # in `range_values`.
-            replacement = replacement.replace(
-                "[{}]".format(match.group("value")),
-                "[{}]".format(range_values[i]),
-                1,
-            )
-
-        for i, match in enumerate(offset_re.finditer(replacement)):
-            # Replace one-by-one, starting from the left. We build the string back with
-            # `str.replace(string_to_replace, replacement_value, count)`. Limit the count
-            # to one, since we are going through one-by-one through the list we saved earlier
-            # in `range_values`.
-            replacement = replacement.replace(
-                "offset {}".format(match.group("value")),
-                "offset {}".format(offset_values[i]),
-                1,
-            )
-
-        # Use the index to insert it back in the same location
-        targets[idx]["expr"] = replacement
-
-    panel["targets"] = targets
-    return panel
 
 
 def _type_convert_stored(obj):
@@ -1050,6 +1044,7 @@ class GrafanaDashboardProvider(Object):
 
         self.framework.observe(self._charm.on.leader_elected, self._update_all_dashboards_from_dir)
         self.framework.observe(self._charm.on.upgrade_charm, self._update_all_dashboards_from_dir)
+        self.framework.observe(self._charm.on.config_changed, self._update_all_dashboards_from_dir)
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created,
@@ -1074,7 +1069,7 @@ class GrafanaDashboardProvider(Object):
         # that the stored state is there when this unit becomes leader.
         stored_dashboard_templates: Any = self._stored.dashboard_templates  # pyright: ignore
 
-        encoded_dashboard = _encode_dashboard_content(content)
+        encoded_dashboard = LZMABase64.compress(content)
 
         # Use as id the first chars of the encoded dashboard, so that
         # it is predictable across units.
@@ -1135,7 +1130,7 @@ class GrafanaDashboardProvider(Object):
                 # path = Path(path)
                 id = "file:{}".format(path.stem)
                 stored_dashboard_templates[id] = self._content_to_dashboard_object(
-                    _encode_dashboard_content(path.read_bytes()), inject_dropdowns
+                    LZMABase64.compress(path.read_bytes()), inject_dropdowns
                 )
                 stored_dashboard_templates[id]["dashboard_alt_uid"] = self._generate_alt_uid(id)
 
@@ -1435,15 +1430,15 @@ class GrafanaDashboardConsumer(Object):
             error = None
             topology = template.get("juju_topology", {})
             try:
-                content = _decode_dashboard_content(template["content"])
+                content = LZMABase64.decompress(template["content"])
                 inject_dropdowns = template.get("inject_dropdowns", True)
                 content = self._manage_dashboard_uid(content, template)
-                content = _convert_dashboard_fields(content, inject_dropdowns)
+                content = CharmedDashboard._convert_dashboard_fields(content, inject_dropdowns)
 
                 if topology:
-                    content = _inject_labels(content, topology, self._tranformer)
+                    content = CharmedDashboard._inject_labels(content, topology, self._tranformer)
 
-                content = _encode_dashboard_content(content)
+                content = LZMABase64.compress(content)
             except lzma.LZMAError as e:
                 error = str(e)
                 relation_has_invalid_dashboards = True
@@ -1532,7 +1527,7 @@ class GrafanaDashboardConsumer(Object):
             "id": dashboard["original_id"],
             "relation_id": relation_id,
             "charm": dashboard["template"]["charm"],
-            "content": _decode_dashboard_content(dashboard["content"]),
+            "content": LZMABase64.decompress(dashboard["content"]),
         }
 
     @property
@@ -1823,7 +1818,7 @@ class GrafanaDashboardAggregator(Object):
 
             from jinja2 import DebugUndefined, Template
 
-            content = _encode_dashboard_content(
+            content = LZMABase64.compress(
                 Template(dash, undefined=DebugUndefined).render(datasource=r"${prometheusds}")  # type: ignore
             )
             id = "prog:{}".format(content[-24:-16])
@@ -1863,7 +1858,7 @@ class GrafanaDashboardAggregator(Object):
                 if event.app.name in path.name:  # type: ignore
                     id = "file:{}".format(path.stem)
                     builtins[id] = self._content_to_dashboard_object(
-                        _encode_dashboard_content(path.read_bytes()), event
+                        LZMABase64.compress(path.read_bytes()), event
                     )
 
         return builtins

--- a/charms/argo-controller/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/charms/argo-controller/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -1,131 +1,18 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""# KubernetesServicePatch Library.
+"""# [DEPRECATED!] KubernetesServicePatch Library.
 
-This library is designed to enable developers to more simply patch the Kubernetes Service created
-by Juju during the deployment of a sidecar charm. When sidecar charms are deployed, Juju creates a
-service named after the application in the namespace (named after the Juju model). This service by
-default contains a "placeholder" port, which is 65536/TCP.
+The `kubernetes_service_patch` library is DEPRECATED and will be removed in October 2025.
 
-When modifying the default set of resources managed by Juju, one must consider the lifecycle of the
-charm. In this case, any modifications to the default service (created during deployment), will be
-overwritten during a charm upgrade.
+For patching the Kubernetes service created by Juju during the deployment of a charm,
+`ops.Unit.set_ports` functionality should be used instead.
 
-When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
-events which applies the patch to the cluster. This should ensure that the service ports are
-correct throughout the charm's life.
-
-The constructor simply takes a reference to the parent charm, and a list of
-[`lightkube`](https://github.com/gtsystem/lightkube) ServicePorts that each define a port for the
-service. For information regarding the `lightkube` `ServicePort` model, please visit the
-`lightkube` [docs](https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#serviceport).
-
-Optionally, a name of the service (in case service name needs to be patched as well), labels,
-selectors, and annotations can be provided as keyword arguments.
-
-## Getting Started
-
-To get started using the library, you just need to fetch the library using `charmcraft`. **Note
-that you also need to add `lightkube` and `lightkube-models` to your charm's `requirements.txt`.**
-
-```shell
-cd some-charm
-charmcraft fetch-lib charms.observability_libs.v1.kubernetes_service_patch
-cat << EOF >> requirements.txt
-lightkube
-lightkube-models
-EOF
-```
-
-Then, to initialise the library:
-
-For `ClusterIP` services:
-
-```python
-# ...
-from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
-from lightkube.models.core_v1 import ServicePort
-
-class SomeCharm(CharmBase):
-  def __init__(self, *args):
-    # ...
-    port = ServicePort(443, name=f"{self.app.name}")
-    self.service_patcher = KubernetesServicePatch(self, [port])
-    # ...
-```
-
-For `LoadBalancer`/`NodePort` services:
-
-```python
-# ...
-from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
-from lightkube.models.core_v1 import ServicePort
-
-class SomeCharm(CharmBase):
-  def __init__(self, *args):
-    # ...
-    port = ServicePort(443, name=f"{self.app.name}", targetPort=443, nodePort=30666)
-    self.service_patcher = KubernetesServicePatch(
-        self, [port], "LoadBalancer"
-    )
-    # ...
-```
-
-Port protocols can also be specified. Valid protocols are `"TCP"`, `"UDP"`, and `"SCTP"`
-
-```python
-# ...
-from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
-from lightkube.models.core_v1 import ServicePort
-
-class SomeCharm(CharmBase):
-  def __init__(self, *args):
-    # ...
-    tcp = ServicePort(443, name=f"{self.app.name}-tcp", protocol="TCP")
-    udp = ServicePort(443, name=f"{self.app.name}-udp", protocol="UDP")
-    sctp = ServicePort(443, name=f"{self.app.name}-sctp", protocol="SCTP")
-    self.service_patcher = KubernetesServicePatch(self, [tcp, udp, sctp])
-    # ...
-```
-
-Bound with custom events by providing `refresh_event` argument:
-For example, you would like to have a configurable port in your charm and want to apply
-service patch every time charm config is changed.
-
-```python
-from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
-from lightkube.models.core_v1 import ServicePort
-
-class SomeCharm(CharmBase):
-  def __init__(self, *args):
-    # ...
-    port = ServicePort(int(self.config["charm-config-port"]), name=f"{self.app.name}")
-    self.service_patcher = KubernetesServicePatch(
-        self,
-        [port],
-        refresh_event=self.on.config_changed
-    )
-    # ...
-```
-
-Additionally, you may wish to use mocks in your charm's unit testing to ensure that the library
-does not try to make any API calls, or open any files during testing that are unlikely to be
-present, and could break your tests. The easiest way to do this is during your test `setUp`:
-
-```python
-# ...
-
-@patch("charm.KubernetesServicePatch", lambda x, y: None)
-def setUp(self, *unused):
-    self.harness = Harness(SomeCharm)
-    # ...
-```
 """
 
 import logging
 from types import MethodType
-from typing import List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from lightkube import ApiError, Client  # pyright: ignore
 from lightkube.core import exceptions
@@ -133,6 +20,7 @@ from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from lightkube.types import PatchType
+from ops import UpgradeCharmEvent
 from ops.charm import CharmBase
 from ops.framework import BoundEvent, Object
 
@@ -146,7 +34,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 13
 
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
@@ -184,12 +72,22 @@ class KubernetesServicePatch(Object):
                 will be observed to re-apply the patch (e.g. on port change).
                 The `install` and `upgrade-charm` events would be observed regardless.
         """
+        logger.warning(
+            "The ``kubernetes_service_patch v1`` library is DEPRECATED and will be removed "
+            "in October 2025. For patching the Kubernetes service created by Juju during "
+            "the deployment of a charm, ``ops.Unit.set_ports`` functionality should be used instead."
+        )
         super().__init__(charm, "kubernetes-service-patch")
         self.charm = charm
-        self.service_name = service_name if service_name else self._app
+        self.service_name = service_name or self._app
+        # To avoid conflicts with the default Juju service, append "-lb" to the service name.
+        # The Juju application name is retained for the default service created by Juju.
+        if self.service_name == self._app and service_type == "LoadBalancer":
+            self.service_name = f"{self._app}-lb"
+        self.service_type = service_type
         self.service = self._service_object(
             ports,
-            service_name,
+            self.service_name,
             service_type,
             additional_labels,
             additional_selectors,
@@ -200,8 +98,11 @@ class KubernetesServicePatch(Object):
         assert isinstance(self._patch, MethodType)
         # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
         self.framework.observe(charm.on.install, self._patch)
-        self.framework.observe(charm.on.upgrade_charm, self._patch)
+        self.framework.observe(charm.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(charm.on.update_status, self._patch)
+        # Sometimes Juju doesn't clean-up a manually created LB service,
+        # so we clean it up ourselves just in case.
+        self.framework.observe(charm.on.remove, self._remove_service)
 
         # apply user defined events
         if refresh_event:
@@ -277,7 +178,10 @@ class KubernetesServicePatch(Object):
             if self._is_patched(client):
                 return
             if self.service_name != self._app:
-                self._delete_and_create_service(client)
+                if not self.service_type == "LoadBalancer":
+                    self._delete_and_create_service(client)
+                else:
+                    self._create_lb_service(client)
             client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
         except ApiError as e:
             if e.status.code == 403:
@@ -293,6 +197,12 @@ class KubernetesServicePatch(Object):
         service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
         client.delete(Service, self._app, namespace=self._namespace)
         client.create(service)
+
+    def _create_lb_service(self, client: Client):
+        try:
+            client.get(Service, self.service_name, namespace=self._namespace)
+        except ApiError:
+            client.create(self.service)
 
     def is_patched(self) -> bool:
         """Reports if the service patch has been applied.
@@ -320,6 +230,60 @@ class KubernetesServicePatch(Object):
             (p.port, p.targetPort) for p in service.spec.ports  # type: ignore[attr-defined]
         ]  # noqa: E501
         return expected_ports == fetched_ports
+
+    def _on_upgrade_charm(self, event: UpgradeCharmEvent):
+        """Handle the upgrade charm event."""
+        # If a charm author changed the service type from LB to ClusterIP across an upgrade, we need to delete the previous LB.
+        if self.service_type == "ClusterIP":
+
+            client = Client()  # pyright: ignore
+
+            # Define a label selector to find services related to the app
+            selector: dict[str, Any] = {"app.kubernetes.io/name": self._app}
+
+            # Check if any service of type LoadBalancer exists
+            services = client.list(Service, namespace=self._namespace, labels=selector)
+            for service in services:
+                if (
+                    not service.metadata
+                    or not service.metadata.name
+                    or not service.spec
+                    or not service.spec.type
+                ):
+                    logger.warning(
+                        "Service patch: skipping resource with incomplete metadata: %s.", service
+                    )
+                    continue
+                if service.spec.type == "LoadBalancer":
+                    client.delete(Service, service.metadata.name, namespace=self._namespace)
+                    logger.info(f"LoadBalancer service {service.metadata.name} deleted.")
+
+        # Continue the upgrade flow normally
+        self._patch(event)
+
+    def _remove_service(self, _):
+        """Remove a Kubernetes service associated with this charm.
+
+        Specifically designed to delete the load balancer service created by the charm, since Juju only deletes the
+        default ClusterIP service and not custom services.
+
+        Returns:
+            None
+
+        Raises:
+            ApiError: for deletion errors, excluding when the service is not found (404 Not Found).
+        """
+        client = Client()  # pyright: ignore
+
+        try:
+            client.delete(Service, self.service_name, namespace=self._namespace)
+            logger.info("The patched k8s service '%s' was deleted.", self.service_name)
+        except ApiError as e:
+            if e.status.code == 404:
+                # Service not found, so no action needed
+                return
+            # Re-raise for other statuses
+            raise
 
     @property
     def _app(self) -> str:

--- a/charms/argo-controller/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/charms/argo-controller/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -178,7 +178,7 @@ configure the following scrape-related settings, which behave as described by th
 - `scrape_timeout`
 - `proxy_url`
 - `relabel_configs`
-- `metrics_relabel_configs`
+- `metric_relabel_configs`
 - `sample_limit`
 - `label_limit`
 - `label_name_length_limit`
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 46
+LIBPATCH = 47
 
 PYDEPS = ["cosl"]
 
@@ -377,7 +377,7 @@ ALLOWED_KEYS = {
     "scrape_timeout",
     "proxy_url",
     "relabel_configs",
-    "metrics_relabel_configs",
+    "metric_relabel_configs",
     "sample_limit",
     "label_limit",
     "label_name_length_limit",

--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: gcr.io/ml-pipeline/workflow-controller:v3.4.16-license-compliance
+    upstream-source: gcr.io/ml-pipeline/workflow-controller:v3.4.17-license-compliance
 containers:
   argo-controller:
     resource: oci-image

--- a/charms/argo-controller/requirements-fmt.txt
+++ b/charms/argo-controller/requirements-fmt.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.12.1
+black==24.8.0
     # via -r requirements-fmt.in
 click==8.1.7
     # via black
@@ -12,13 +12,13 @@ isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.2
+packaging==24.2
     # via black
 pathspec==0.12.1
     # via black
-platformdirs==4.1.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via black

--- a/charms/argo-controller/requirements-integration.txt
+++ b/charms/argo-controller/requirements-integration.txt
@@ -4,43 +4,45 @@
 #
 #    pip-compile requirements-integration.in
 #
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.10.11
     # via -r requirements-integration.in
 aiosignal==1.3.1
     # via aiohttp
-anyio==4.4.0
+anyio==4.5.2
     # via httpx
-appnope==0.1.4
-    # via ipython
-asttokens==2.4.1
+asttokens==3.0.0
     # via stack-data
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.3
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.3.3
+cachetools==5.5.0
     # via google-auth
-certifi==2024.6.2
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.1
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cryptography==42.0.8
+cryptography==44.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -48,33 +50,33 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-executing==2.0.1
+executing==2.1.0
     # via stack-data
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.30.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.27.2
     # via lightkube
-hvac==2.2.0
+hvac==2.3.0
     # via juju
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
     #   yarl
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -82,7 +84,7 @@ ipdb==0.13.13
     # via pytest-operator
 ipython==8.12.3
     # via ipdb
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -91,16 +93,16 @@ jinja2==3.1.4
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.5.0.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.2
+lightkube==0.15.6
     # via charmed-kubeflow-chisme
-lightkube-models==1.30.0.8
+lightkube-models==1.31.1.8
     # via lightkube
 macaroonbakery==1.3.4
     # via juju
@@ -108,7 +110,7 @@ markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.7
     # via ipython
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
@@ -118,17 +120,17 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.0
+ops==2.17.1
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.0
+packaging==24.2
     # via
     #   juju
     #   pytest
-paramiko==3.4.0
+paramiko==3.5.0
     # via juju
 parso==0.8.4
     # via jedi
@@ -140,20 +142,22 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.46
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==5.27.1
+propcache==0.2.0
+    # via yarl
+protobuf==5.29.1
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
@@ -172,19 +176,19 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.2.2
+pytest==8.3.4
     # via
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.35.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   juju
     #   kubernetes
@@ -210,9 +214,8 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-six==1.16.0
+six==1.17.0
     # via
-    #   asttokens
     #   kubernetes
     #   macaroonbakery
     #   pymacaroons
@@ -223,11 +226,11 @@ sniffio==1.3.1
     #   httpx
 stack-data==0.6.3
     # via ipython
-tenacity==8.3.0
+tenacity==9.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
@@ -237,14 +240,16 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   anyio
     #   ipython
+    #   juju
+    #   multidict
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.1
+urllib3==2.2.3
     # via
     #   kubernetes
     #   requests
@@ -254,9 +259,9 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+websockets==13.1
     # via juju
-yarl==1.9.4
+yarl==1.15.2
     # via aiohttp
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/argo-controller/requirements-lint.txt
+++ b/charms/argo-controller/requirements-lint.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.12.1
+black==24.8.0
     # via -r requirements-lint.in
 click==8.1.7
     # via black
-codespell==2.2.6
+codespell==2.3.0
     # via -r requirements-lint.in
 colorama==0.4.6
     # via -r requirements-lint.in
-flake8==6.1.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.2.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
@@ -28,25 +28,25 @@ mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.2
+packaging==24.2
     # via black
 pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==4.1.0
+platformdirs==4.3.6
     # via black
 pycodestyle==2.11.1
     # via flake8
-pyflakes==3.1.0
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.1.0
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/argo-controller/requirements-unit.txt
+++ b/charms/argo-controller/requirements-unit.txt
@@ -4,58 +4,92 @@
 #
 #    pip-compile requirements-unit.in
 #
-anyio==4.2.0
+annotated-types==0.7.0
+    # via
+    #   -r requirements.txt
+    #   pydantic
+anyio==4.5.2
     # via
     #   -r requirements.txt
     #   httpx
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   -r requirements.txt
     #   jsonschema
-certifi==2023.11.17
+backports-strenum==1.3.1
+    # via
+    #   -r requirements.txt
+    #   juju
+bcrypt==4.2.1
+    # via
+    #   -r requirements.txt
+    #   paramiko
+cachetools==5.5.0
+    # via
+    #   -r requirements.txt
+    #   google-auth
+certifi==2024.8.30
     # via
     #   -r requirements.txt
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.1
+cffi==1.17.1
+    # via
+    #   -r requirements.txt
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.txt
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via
     #   -r requirements.txt
     #   requests
-cosl==0.0.7
+cosl==0.0.45
     # via -r requirements.txt
-coverage==7.4.0
+coverage==7.6.1
     # via -r requirements-unit.in
+cryptography==44.0.0
+    # via
+    #   -r requirements.txt
+    #   paramiko
 deepdiff==6.2.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via
     #   -r requirements.txt
     #   anyio
     #   pytest
+google-auth==2.36.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
 h11==0.14.0
     # via
     #   -r requirements.txt
     #   httpcore
-httpcore==1.0.2
+httpcore==1.0.7
     # via
     #   -r requirements.txt
     #   httpx
-httpx==0.26.0
+httpx==0.27.2
     # via
     #   -r requirements.txt
     #   lightkube
-idna==3.6
+hvac==2.3.0
+    # via
+    #   -r requirements.txt
+    #   juju
+idna==3.10
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via
     #   -r requirements.txt
     #   jsonschema
@@ -69,19 +103,41 @@ jsonschema==4.17.3
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-lightkube==0.15.0
+juju==3.6.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.6
+kubernetes==30.1.0
+    # via
+    #   -r requirements.txt
+    #   juju
+lightkube==0.15.6
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
+    #   cosl
+lightkube-models==1.31.1.8
     # via
     #   -r requirements.txt
     #   lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via
+    #   -r requirements.txt
+    #   juju
+markupsafe==2.1.5
     # via
     #   -r requirements.txt
     #   jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements.txt
+    #   typing-inspect
+oauthlib==3.2.2
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -91,36 +147,106 @@ ordered-set==4.1.0
     # via
     #   -r requirements.txt
     #   deepdiff
-packaging==23.2
-    # via pytest
+packaging==24.2
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pytest
+paramiko==3.5.0
+    # via
+    #   -r requirements.txt
+    #   juju
 pkgutil-resolve-name==1.3.10
     # via
     #   -r requirements.txt
     #   jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
+protobuf==5.29.1
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via
+    #   -r requirements.txt
+    #   google-auth
+pycparser==2.22
+    # via
+    #   -r requirements.txt
+    #   cffi
+pydantic==2.10.3
+    # via
+    #   -r requirements.txt
+    #   cosl
+pydantic-core==2.27.1
+    # via
+    #   -r requirements.txt
+    #   pydantic
+pymacaroons==0.13.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+pynacl==1.5.0
+    # via
+    #   -r requirements.txt
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   -r requirements.txt
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via
     #   -r requirements.txt
     #   jsonschema
-pytest==7.4.4
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+pytz==2024.2
+    # via
+    #   -r requirements.txt
+    #   pyrfc3339
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements.txt
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
     #   serialized-data-interface
-ruamel-yaml==0.18.5
+requests-oauthlib==2.0.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+rsa==4.9
+    # via
+    #   -r requirements.txt
+    #   google-auth
+ruamel-yaml==0.18.6
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
@@ -132,31 +258,58 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.17.0
+    # via
+    #   -r requirements.txt
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   -r requirements.txt
     #   anyio
     #   httpx
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements.txt
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+    #   cosl
+tomli==2.2.1
     # via pytest
-typing-extensions==4.9.0
+toposort==1.10
     # via
     #   -r requirements.txt
+    #   juju
+typing-extensions==4.12.2
+    # via
+    #   -r requirements.txt
+    #   annotated-types
     #   anyio
     #   cosl
-urllib3==2.1.0
+    #   juju
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
     # via
     #   -r requirements.txt
+    #   juju
+urllib3==2.2.3
+    # via
+    #   -r requirements.txt
+    #   kubernetes
     #   requests
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via
     #   -r requirements.txt
+    #   kubernetes
     #   ops
-zipp==3.17.0
+websockets==13.1
+    # via
+    #   -r requirements.txt
+    #   juju
+zipp==3.20.2
     # via
     #   -r requirements.txt
     #   importlib-resources

--- a/charms/argo-controller/requirements-unit.txt
+++ b/charms/argo-controller/requirements-unit.txt
@@ -46,7 +46,7 @@ charset-normalizer==3.4.0
     # via
     #   -r requirements.txt
     #   requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.txt
 coverage==7.6.1
     # via -r requirements-unit.in

--- a/charms/argo-controller/requirements.txt
+++ b/charms/argo-controller/requirements.txt
@@ -30,7 +30,7 @@ charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.in
 cryptography==44.0.0
     # via paramiko

--- a/charms/argo-controller/requirements.txt
+++ b/charms/argo-controller/requirements.txt
@@ -4,51 +4,83 @@
 #
 #    pip-compile requirements.in
 #
-anyio==4.2.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2023.11.17
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
+    # via paramiko
+cachetools==5.5.0
+    # via google-auth
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.1
+cffi==1.17.1
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.7
+cosl==0.0.45
     # via -r requirements.in
+cryptography==44.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.36.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.2
+httpcore==1.0.7
     # via httpx
-httpx==0.26.0
+httpx==0.27.2
     # via lightkube
-idna==3.6
+hvac==2.3.0
+    # via juju
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.1.1
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.0
+juju==3.6.0.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.6
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.29.0.6
+    #   cosl
+lightkube-models==1.31.1.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -56,19 +88,64 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.2
+    # via juju
+paramiko==3.5.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
+protobuf==5.29.1
+    # via macaroonbakery
+pyasn1==0.6.1
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pydantic==2.10.3
+    # via cosl
+pydantic-core==2.27.1
+    # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.2
+    # via pyrfc3339
+pyyaml==6.0.2
     # via
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.18.5
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
@@ -76,19 +153,42 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.17.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-tenacity==8.2.3
-    # via charmed-kubeflow-chisme
-typing-extensions==4.9.0
+tenacity==9.0.0
     # via
+    #   charmed-kubeflow-chisme
+    #   cosl
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
+    # via
+    #   annotated-types
     #   anyio
     #   cosl
-urllib3==2.1.0
-    # via requests
-websocket-client==1.7.0
-    # via ops
-zipp==3.17.0
+    #   juju
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.3
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==13.1
+    # via juju
+zipp==3.20.2
     # via importlib-resources

--- a/charms/argo-controller/tox.ini
+++ b/charms/argo-controller/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]
@@ -55,7 +57,8 @@ commands =
     codespell {toxinidir}/. --skip {toxinidir}/./.git --skip {toxinidir}/./.tox \
       --skip {toxinidir}/./build --skip {toxinidir}/./lib --skip {toxinidir}/./venv \
       --skip {toxinidir}/./.mypy_cache \
-      --skip {toxinidir}/./icon.svg --skip *.json.tmpl
+      --skip {toxinidir}/./icon.svg --skip *.json.tmpl \
+      --skip {toxinidir}/./src/templates/*
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,6 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv =
     integration: TYPE = integration
     update-requirements: TYPE = update-requirements
 commands =
-    tox -vve {env:TYPE} -c {toxinidir}/charms/{env:CHARM}
+    tox  -c {toxinidir}/charms/{env:CHARM} -vve {env:TYPE}
 
 [testenv:update-requirements]
 allowlist_externals =


### PR DESCRIPTION
Backport CI changes and dependency updates in order to ensure argo-controller from 3.4/stable is up-to-date WRT releasing CKF 1.10.

A follow-up PR will be sent to enable running integration tests both in 1.29 and 1.31 since this charm is used both in CKF 1.9 and 1.10.

Ref https://warthogs.atlassian.net/browse/KF-6860.