### PR TITLE
Update argo-exec rock

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -12,7 +12,7 @@ options:
     description: S3 key prefix
   executor-image:
     type: string
-    default: gcr.io/ml-pipeline/argoexec:v3.4.17-license-compliance
+    default: charmedkubeflow/argoexec:3.4.17-ae093c9
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:


### PR DESCRIPTION
This PR updates the `argo-exec` rock with the version used in CKF 1.10. The rock was published in [this action](https://github.com/canonical/argo-workflows-rocks/actions/runs/13173637809/job/36768837828).