### PR TITLE
ci: migrate GH runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -71,10 +71,7 @@ jobs:
     - name: Build and test
       working-directory: ./charms/${{ matrix.charm }}
       run: |
-        # microk8s permissions required due to tests running `microk8s kubectl` commands  
-        # `sg` does not work in GitHub Actions; use `sudo --user` instead
-        # see https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
-        sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -vve integration -- --model testing
+        tox -vve integration -- --model testing
 
       # On failure, capture debugging resources
     - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -17,19 +17,27 @@ jobs:
 
   lint:
     name: Lint Code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
     - run: pip install tox
     - run: tox -vve argo-controller-lint
 
   unit:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out repo
       uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
     - run: pip install tox
     - run: tox -vve argo-controller-unit
 
@@ -41,12 +49,16 @@ jobs:
 
   integration:
     name: Integration Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         charm: [argo-controller]
     steps:
     - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
@@ -59,7 +71,7 @@ jobs:
     - name: Build and test
       working-directory: ./charms/${{ matrix.charm }}
       run: |
-        sg snap_microk8s -c "tox -vve integration -- --model testing"
+        tox -vve integration -- --model testing
 
       # On failure, capture debugging resources
     - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -71,7 +71,10 @@ jobs:
     - name: Build and test
       working-directory: ./charms/${{ matrix.charm }}
       run: |
-        tox -vve integration -- --model testing
+        # microk8s permissions required due to tests running `microk8s kubectl` commands  
+        # `sg` does not work in GitHub Actions; use `sudo --user` instead
+        # see https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+        sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -vve integration -- --model testing
 
       # On failure, capture debugging resources
     - name: Get all

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: get-charm-paths
     strategy:
       fail-fast: false
@@ -83,6 +83,12 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
+      # Required to charmcraft pack in non-destructive mode
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
@@ -92,3 +98,4 @@ jobs:
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: 3.x/stable
+          destructive-mode: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Release charm to channel

--- a/charms/argo-controller/tests/integration/test_charm.py
+++ b/charms/argo-controller/tests/integration/test_charm.py
@@ -76,7 +76,6 @@ async def create_artifact_bucket(ops_test: OpsTest):
         f"&& mc mb {alias}/{bucket} -p"
     )
     kubectl_cmd = (
-        "microk8s",
         "kubectl",
         "run",
         "--rm",
@@ -101,7 +100,6 @@ async def create_artifact_bucket(ops_test: OpsTest):
 
 async def submit_workflow_using_artifact(ops_test: OpsTest):
     kubectl_cmd = (
-        "microk8s",
         "kubectl",
         f"--namespace={ops_test.model_name}",
         "create",
@@ -119,7 +117,6 @@ async def submit_workflow_using_artifact(ops_test: OpsTest):
     log.info(f"Waiting on {workflow_name} to finish")
 
     kubectl_wait_cmd = (
-        "microk8s",
         "kubectl",
         f"--namespace={ops_test.model_name}",
         "wait",


### PR DESCRIPTION
Closes #231

* update GH runners from 20.04 to 24.04
* use setup-python action to setup python 3.8
* edit the integration tests to use `kubectl` instead of `microk8s kubectl` so that elevated permissions are not needed
* removes `sg` no longer needed based on the previous point