### PR TITLE
tests: Keep charms-dependencies in dependencies.py

### DIFF
--- a/charms/argo-controller/tests/integration/dependencies.py
+++ b/charms/argo-controller/tests/integration/dependencies.py
@@ -1,0 +1,6 @@
+MINIO = "minio"
+MINIO_CHANNEL = "latest/edge"
+MINIO_CONFIG = {
+    "access-key": "minio",
+    "secret-key": "minio-secret-key",
+}

--- a/charms/argo-controller/tests/integration/test_charm.py
+++ b/charms/argo-controller/tests/integration/test_charm.py
@@ -14,18 +14,18 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from dependencies import (
+    MINIO,
+    MINIO_CHANNEL,
+    MINIO_CONFIG
+)
 from pytest_operator.plugin import OpsTest
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_ROOT = "."
 ARGO_CONTROLLER = "argo-controller"
 ARGO_CONTROLLER_TRUST = True
-MINIO = "minio"
-MINIO_CHANNEL = "latest/edge"
-MINIO_CONFIG = {
-    "access-key": "minio",
-    "secret-key": "minio-secret-key",
-}
+
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Keep charms-dependencies that are deployed during integration in a distinct dependencies.py file to enable managing them automatically.

Ref https://github.com/canonical/bundle-kubeflow/issues/1256