### PR TITLE
Use `data` instead of `stringData` for minio access_key and secret_key

### DIFF
--- a/charms/argo-controller/src/templates/mlpipeline_minio_artifact_secret.yaml.j2
+++ b/charms/argo-controller/src/templates/mlpipeline_minio_artifact_secret.yaml.j2
@@ -5,7 +5,7 @@ metadata:
     app: minio
   name: {{ mlpipeline_minio_artifact_secret }}
   namespace: {{ namespace }}
-stringData:
+data:
   accesskey: {{ access_key }}
   secretkey: {{ secret_key }}
 type: Opaque


### PR DESCRIPTION
Closes #237 

This PR simply replaces the `stringData` field in the `mlpipeline-minio-artifact` secret to a `data` field. This fixes the double encoding issue described in #237.

## To test
Deploy the necessary charms, and write a sample workflow file:
```
juju deploy argo-controller --channel 3.4/stable 
juju trust argo-controller --scope=cluster
juju deploy minio --channel ckf-1.9/stable
juju relate argo-controller minio

cat <<EOF > hello-world-workflow.yaml
apiVersion: argoproj.io/v1alpha1
kind: Workflow
metadata:
  generateName: hello-world-
spec:
  entrypoint: hello-world

  templates:
  - name: hello-world
    container:
      image: alpine:latest
      command: ["echo"]
      args: ["Hello, Argo Workflow!"]
EOF
```
Then, apply the workflow to the `kubeflow` namespace:
```
kubectl create -f hello-world-workflow.yaml -n kubeflow
```
Note that you may need to create a serviceaccount in the `kubeflow` namespace and the respective rolebinding to `default-editor`, unless you may receive the following error:
```
hello-world-vh6bx   Error     21m    Error (exit code 1): pods "hello-world-vh6bx" is forbidden: User "system:serviceaccount:kubeflow:default" cannot patch resource "pods" in API group "" in the namespace "kubeflow"
```