### PR TITLE
feat: update argo-controller manifests to 3.5.14

### DIFF
--- a/charms/argo-controller/config.yaml
+++ b/charms/argo-controller/config.yaml
@@ -12,7 +12,7 @@ options:
     description: S3 key prefix
   executor-image:
     type: string
-    default: charmedkubeflow/argoexec:3.4.17-ae093c9
+    default: quay.io/argoproj/argoexec:v3.5.14
     description: |
       Image to use for runtime executor. Should be updated alongside updating the rest of the charm's images.
   kubelet-insecure:

--- a/charms/argo-controller/metadata.yaml
+++ b/charms/argo-controller/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: charmedkubeflow/workflow-controller:3.4.17-627976f
+    upstream-source: quay.io/argoproj/workflow-controller:v3.5.14
 containers:
   argo-controller:
     resource: oci-image

--- a/charms/argo-controller/src/prometheus_alert_rules/missing_pods.rule
+++ b/charms/argo-controller/src/prometheus_alert_rules/missing_pods.rule
@@ -8,4 +8,4 @@ annotations:
   description: >
     Detected missing workflow pods in the last 5 minutes.
     Missing pods are expected pods that never appeared or were deleted.
-    See https://argo-workflows.readthedocs.io/en/release-3.4/metrics/#argo_pod_missing for details.
+    See https://argo-workflows.readthedocs.io/en/release-3.5/metrics/#argo_pod_missing for details.

--- a/charms/argo-controller/src/templates/crds.yaml
+++ b/charms/argo-controller/src/templates/crds.yaml
@@ -64,6 +64,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: CompositeController
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -89,6 +90,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                         statusChecks:
                           properties:
@@ -118,9 +125,34 @@ spec:
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -138,6 +170,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -145,9 +178,34 @@ spec:
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -165,6 +223,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -172,9 +231,34 @@ spec:
                     type: object
                   postUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -192,6 +276,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -199,9 +284,34 @@ spec:
                     type: object
                   preUpdateChild:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -219,6 +329,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -226,9 +337,34 @@ spec:
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -246,6 +382,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -256,6 +393,54 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  labelSelector:
+                    description: A label selector is a label query over a set of resources.
+                      The result of matchLabels and matchExpressions are ANDed. An
+                      empty label selector matches all objects. A null label selector
+                      matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
                   resource:
                     type: string
                   revisionHistory:
@@ -285,12 +470,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -313,6 +492,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ControllerRevision
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -345,6 +525,7 @@ spec:
             type: object
           parentPatch:
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         required:
         - metadata
         - parentPatch
@@ -353,12 +534,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -429,6 +604,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: DecoratorController
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -454,6 +630,12 @@ spec:
                     updateStrategy:
                       properties:
                         method:
+                          enum:
+                          - OnDelete
+                          - Recreate
+                          - InPlace
+                          - RollingRecreate
+                          - RollingInPlace
                           type: string
                       type: object
                   required:
@@ -465,9 +647,34 @@ spec:
                 properties:
                   customize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -485,6 +692,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -492,9 +700,34 @@ spec:
                     type: object
                   finalize:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -512,6 +745,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -519,9 +753,34 @@ spec:
                     type: object
                   sync:
                     properties:
+                      version:
+                        default: v1
+                        enum:
+                        - v1
+                        - v2
+                        type: string
                       webhook:
                         properties:
+                          etag:
+                            properties:
+                              cacheCleanupSeconds:
+                                format: int32
+                                type: integer
+                              cacheTimeoutSeconds:
+                                format: int32
+                                type: integer
+                              enabled:
+                                type: boolean
+                            type: object
                           path:
+                            type: string
+                          responseUnMarshallMode:
+                            description: Sets the json unmarshall mode. One of the
+                              'loose' or 'strict'. In 'strict' mode additional checks
+                              are performed to detect unknown and duplicated fields.
+                            enum:
+                            - loose
+                            - strict
                             type: string
                           service:
                             properties:
@@ -539,6 +798,7 @@ spec:
                             - namespace
                             type: object
                           timeout:
+                            format: duration
                             type: string
                           url:
                             type: string
@@ -633,6 +893,7 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
+                      x-kubernetes-map-type: atomic
                     resource:
                       type: string
                   required:
@@ -656,12 +917,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1331,6 +1586,8 @@ spec:
                           type: object
                         securityToken:
                           type: string
+                        useSDKCreds:
+                          type: boolean
                       required:
                       - key
                       type: object
@@ -1360,6 +1617,17 @@ spec:
                           type: object
                         bucket:
                           type: string
+                        caSecret:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          required:
+                          - key
+                          type: object
                         createBucketIfNotPresent:
                           properties:
                             objectLocking:


### PR DESCRIPTION
Closes #274 

Manifests generated by following [upstream instructions](https://github.com/kubeflow/manifests?tab=readme-ov-file#kubeflow-pipelines) using kustomize

Note that for now the upstream images are being used, rocks shall be integrated next in #275 