### PR TITLE
feat(security): run the argo-controller service as _daemon_ user

### DIFF
--- a/charms/argo-controller/src/components/pebble_component.py
+++ b/charms/argo-controller/src/components/pebble_component.py
@@ -58,6 +58,7 @@ class ArgoControllerPebbleService(PebbleServiceComponent):
                             f"{self.model.config[EXECUTOR_IMAGE_CONFIG_NAME]}"
                         ),
                         "startup": "enabled",
+                        "user": "_daemon_", # This is needed only for rocks
                         "environment": self.environment,
                         "on-check-failure": {LIVENESS_PROBE_NAME: "restart"},
                     }


### PR DESCRIPTION
Run the pebble service as non-root as discussed in https://github.com/canonical/kfp-operators/issues/675, similarly to upstream running the container [as non-root](https://github.com/kubeflow/manifests/blob/master/applications/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-deployment.yaml#L51)