### PR TITLE
ci: add Ubuntu base argument to risk promotion action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.6.2
         with:
+          base-channel: '24.04'
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}


### PR DESCRIPTION
This pull request explicitly sets the argument for the Ubuntu base of the CharmHub promotion action so that it is no longer using the [default version](https://github.com/canonical/charming-actions/blob/main/release-charm/action.yaml#L24), which is outdated and no longer used by this charm, but the same version as the charm is using now.