### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -46,6 +46,15 @@ jobs:
       matrix:
         charm: [argo-controller]
     steps:
+    - name: Maximise GH runner space
+      uses: easimon/maximize-build-space@v8
+      with:
+        root-reserve-mb: 34816
+        remove-dotnet: 'true'
+        remove-haskell: 'true'
+        remove-android: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: pipx install tox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,10 @@ jobs:
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.6.2
         with:
-          base-channel: '24.04'
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: '24.04'
           tag-prefix: ${{ github.event.inputs.charm-name }}
           charm-path: charms/${{ github.event.inputs.charm-name}}

--- a/charms/argo-controller/terraform/README.md
+++ b/charms/argo-controller/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/argo-controller/terraform/main.tf
+++ b/charms/argo-controller/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "argo_controller" {
   charm {
     name     = "argo-controller"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/argo-controller/terraform/variables.tf
+++ b/charms/argo-controller/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "argo-controller"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR is a backport of #292.