### PR TITLE
chore: pin charm dependencies in tests (track/3.7)

### DIFF
--- a/charms/argo-controller/tests/integration/charms_dependencies.py
+++ b/charms/argo-controller/tests/integration/charms_dependencies.py
@@ -4,7 +4,7 @@ from charmed_kubeflow_chisme.testing import CharmSpec
 
 MINIO = CharmSpec(
     charm="minio",
-    channel="latest/edge",
+    channel="1.10/edge",
     trust=False,
     config={
         "access-key": "minio",


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11)
- `minio`: `latest/edge` → `1.10/edge`

Refs: canonical/bundle-kubeflow#1379
