### PR TITLE
fix: add permissions write to publish charms

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -29,3 +29,5 @@ jobs:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
     secrets: inherit
+    permissions:
+      contents: write  # Needed to create git tags

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -26,3 +26,5 @@ jobs:
     needs: tests
     uses: ./.github/workflows/publish.yaml
     secrets: inherit
+    permissions:
+      contents: write  # Needed to create git tags


### PR DESCRIPTION
This PR adds write permissions to publish charm action, required to create tags.
By default, `GITHUB_TOKEN` is issued with the following permissions:
```
Permissions
  Contents: read
  Metadata: read
  Packages: read
```
which are not enough. The PR adds `contents: write` privileges to the token.

Ref: canonical/bundle-kubeflow/issues/1442