### PR TITLE
fix: Grant proper permissions to ci-tests job in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
     secrets: inherit
     permissions:
       actions: read
+      contents: read
 
   release:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
+    permissions:
+      actions: read
 
   release:
     strategy:


### PR DESCRIPTION
## Summary

This is a small PR to update the `ci-tests` caller jobs in `release.yaml` with `actions:read` and `contents: read`, to avoid the following error run:
- https://github.com/canonical/argo-operators/actions/runs/26499247519
- https://github.com/canonical/minio-operator/actions/runs/26540022652
