### PR TITLE
Use 2/stable channel for s3-integrator in integration tests

### DIFF
--- a/charms/argo-controller/tests/integration/charms_dependencies.py
+++ b/charms/argo-controller/tests/integration/charms_dependencies.py
@@ -14,6 +14,6 @@ MINIO = CharmSpec(
 
 S3_INTEGRATOR = CharmSpec(
     charm="s3-integrator",
-    channel="2/edge",
+    channel="2/stable",
     trust=False,
 )


### PR DESCRIPTION
## Summary
This PR updates the charm dependency for `s3-integrator` in all integration tests to use `2/stable`.

Base issue: https://github.com/canonical/bundle-kubeflow/issues/1456