### PR TITLE
fix: Add s3-credentials relation to terraform module

### DIFF
--- a/charms/argo-controller/terraform/outputs.tf
+++ b/charms/argo-controller/terraform/outputs.tf
@@ -11,6 +11,7 @@ output "provides" {
 
 output "requires" {
   value = {
+    s3_credentials = "s3-credentials",
     object_storage = "object-storage",
     logging        = "logging"
   }


### PR DESCRIPTION
This PR adds a missing `s3-credentials` output to the Terraform module.